### PR TITLE
us120285 implement bsi style tokens

### DIFF
--- a/src/components/d2l-discover-list/d2l-discover-list.js
+++ b/src/components/d2l-discover-list/d2l-discover-list.js
@@ -263,7 +263,7 @@ class D2lDiscoverList extends LocalizeMixin(DiscoverListItemResponsiveConstants(
 			.fetch(new Request(url, {
 				headers: {
 					Accept: 'application/vnd.siren+json',
-					Authorization: 'Bearer ' + window.D2L.token
+					Authorization: 'Bearer ' + this.token
 				},
 			}))
 			.then(this._responseToSirenEntity.bind(this));

--- a/src/components/d2l-discover-list/d2l-discover-list.js
+++ b/src/components/d2l-discover-list/d2l-discover-list.js
@@ -261,7 +261,10 @@ class D2lDiscoverList extends LocalizeMixin(DiscoverListItemResponsiveConstants(
 
 		return window.d2lfetch
 			.fetch(new Request(url, {
-				headers: { Accept: 'application/vnd.siren+json' },
+				headers: {
+					Accept: 'application/vnd.siren+json',
+					Authorization: 'Bearer ' + window.D2L.token
+				},
 			}))
 			.then(this._responseToSirenEntity.bind(this));
 	}

--- a/src/components/d2l-discover-list/d2l-discover-list.js
+++ b/src/components/d2l-discover-list/d2l-discover-list.js
@@ -5,18 +5,17 @@ import '@brightspace-ui/core/components/list/list.js';
 import '@brightspace-ui/core/components/list/list-item.js';
 import '@brightspace-ui/core/components/list/list-item-content.js';
 import 'fastdom/fastdom.min.js';
-import 'd2l-fetch/d2l-fetch.js';
 import 'd2l-organizations/components/d2l-organization-name/d2l-organization-name.js';
 import 'd2l-organizations/components/d2l-organization-image/d2l-organization-image.js';
-import SirenParse from 'siren-parser';
 import { Rels } from 'd2l-hypermedia-constants';
 import { heading1Styles, heading2Styles, heading4Styles, bodyCompactStyles, bodyStandardStyles, labelStyles} from '@brightspace-ui/core/components/typography/styles.js';
 import { DiscoverListItemResponsiveConstants } from './DiscoverListItemResponsiveConstants.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { getLocalizeResources } from '../../localization.js';
 import { OrganizationEntity } from 'siren-sdk/src/organizations/OrganizationEntity.js';
+import { FetchMixin } from '../../mixins/fetch-mixin.js';
 
-class D2lDiscoverList extends LocalizeMixin(DiscoverListItemResponsiveConstants(LitElement)) {
+class D2lDiscoverList extends FetchMixin(LocalizeMixin(DiscoverListItemResponsiveConstants(LitElement))) {
 	constructor() {
 		super();
 		this._descriptionPlaceholderLines = [{}, {}];
@@ -254,31 +253,6 @@ class D2lDiscoverList extends LocalizeMixin(DiscoverListItemResponsiveConstants(
 		return accessibilityText;
 	}
 
-	_fetchEntity(url) {
-		if (!url) {
-			return;
-		}
-
-		return window.d2lfetch
-			.fetch(new Request(url, {
-				headers: {
-					Accept: 'application/vnd.siren+json',
-					Authorization: 'Bearer ' + this.token
-				},
-			}))
-			.then(this._responseToSirenEntity.bind(this));
-	}
-
-	_responseToSirenEntity(response) {
-		if (response.ok) {
-			return response
-				.json()
-				.then(function(json) {
-					return SirenParse(json);
-				});
-		}
-		return Promise.reject(response.status + ' ' + response.statusText);
-	}
 
 	_shouldRenderTextSkeletons() {
 		return !this._loadedText || this.textPlaceholder;

--- a/src/components/d2l-discover-list/d2l-discover-list.js
+++ b/src/components/d2l-discover-list/d2l-discover-list.js
@@ -253,7 +253,6 @@ class D2lDiscoverList extends FetchMixin(LocalizeMixin(DiscoverListItemResponsiv
 		return accessibilityText;
 	}
 
-
 	_shouldRenderTextSkeletons() {
 		return !this._loadedText || this.textPlaceholder;
 	}

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -187,7 +187,10 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 	//Retrieves a token for interacting with the BFF
 	async _tokenChanged(newValue, oldValue) {
 		if (!oldValue) {
-			this.token = this.initializeToken(newValue);
+			this._initializeToken(newValue);
+			this._getToken(newValue).then((token) => {
+				this.token = token;
+			});
 		}
 	}
 	_resetPage(pageName) {

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -44,25 +44,28 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 				tail="[[subroute]]">
 			</app-route>
 
-			<iron-pages
-				selected="[[page]]"
-				attr-for-selected="name"
-				selected-attribute="visible"
-				role="main">
-				<discovery-home
-					name="home"
-					promoted-courses-enabled="[[_promotedCoursesEnabled]]"
-					can-manage-discover="[[_manageDiscover]]"></discovery-home>
-				<discovery-course name="course" route="[[route]]"></discovery-course>
-				<discovery-search name="search" route="[[route]]"></discovery-search>
-				<discovery-settings
-					name="settings"
-					can-manage-discover="[[_manageDiscover]]"
-					discover-customizations-enabled = "[[_discoverCustomizationsEnabled]]"
-					discover-toggle-sections-enabled = "[[_discoverToggleSectionsEnabled]]">
-				</discovery-settings>
-				<discovery-404 name="404"></discovery-404>
-			</iron-pages>
+
+			<template is="dom-if" if="[[_isDiscoverInitialized(token, options)]]">
+				<iron-pages
+					selected="[[page]]"
+					attr-for-selected="name"
+					selected-attribute="visible"
+					role="main">
+					<discovery-home
+						name="home"
+						promoted-courses-enabled="[[_promotedCoursesEnabled]]"
+						can-manage-discover="[[_manageDiscover]]"></discovery-home>
+					<discovery-course name="course" route="[[route]]"></discovery-course>
+					<discovery-search name="search" route="[[route]]"></discovery-search>
+					<discovery-settings
+						name="settings"
+						can-manage-discover="[[_manageDiscover]]"
+						discover-customizations-enabled = "[[_discoverCustomizationsEnabled]]"
+						discover-toggle-sections-enabled = "[[_discoverToggleSectionsEnabled]]">
+					</discovery-settings>
+					<discovery-404 name="404"></discovery-404>
+				</iron-pages>
+			</template>
 		`;
 	}
 	static get properties() {
@@ -184,6 +187,12 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 		this._discoverToggleSectionsEnabled = this._isDiscoverToggleSectionsEnabled();
 	}
 
+	_isDiscoverInitialized(token, options) {
+		if(token && options) {
+			return true;
+		}
+		return false;
+	}
 	//Retrieves a token for interacting with the BFF
 	async _tokenChanged(newValue, oldValue) {
 		if (!oldValue) {

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -186,7 +186,7 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 
 	//Retrieves a token for interacting with the BFF
 	async _tokenChanged(newValue, oldValue) {
-		if(!oldValue) {
+		if (!oldValue) {
 			this.token = this.initializeToken(newValue);
 		}
 	}

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -102,8 +102,8 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 			_discoverToggleSectionsEnabled: {
 				type: Boolean
 			}
-		}
-	};
+		};
+	}
 
 	constructor() {
 		super();
@@ -188,7 +188,7 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 	}
 
 	_isDiscoverInitialized(token, options) {
-		if(token && options) {
+		if (token && options) {
 			return true;
 		}
 		return false;

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -11,6 +11,7 @@ import './discovery-settings.js';
 
 import { IfrauMixin } from './mixins/ifrau-mixin.js';
 import { FeatureMixin } from './mixins/feature-mixin.js';
+import { FetchMixin } from './mixins/fetch-mixin.js';
 import { RouteLocationsMixin } from './mixins/route-locations-mixin.js';
 
 // Gesture events like tap and track generated from touch will not be
@@ -22,7 +23,7 @@ setPassiveTouchGestures(true);
 window.DiscoveryApp = window.DiscoveryApp || {};
 setRootPath(window.DiscoveryApp.rootPath);
 
-class DiscoveryApp extends FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerElement))) {
+class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerElement)))) {
 	static get template() {
 		return html`
 			<style>
@@ -70,6 +71,10 @@ class DiscoveryApp extends FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerEl
 				type: String,
 				observer: '_optionsChanged'
 			},
+			token: {
+				type: String,
+				observer: '_tokenChanged'
+			},
 			page: {
 				type: String,
 				reflectToAttribute: true
@@ -94,8 +99,9 @@ class DiscoveryApp extends FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerEl
 			_discoverToggleSectionsEnabled: {
 				type: Boolean
 			}
-		};
-	}
+		}
+	};
+
 	constructor() {
 		super();
 		this._routeDataChangedHandled = this._routeDataChanged.bind(this);
@@ -178,6 +184,12 @@ class DiscoveryApp extends FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerEl
 		this._discoverToggleSectionsEnabled = this._isDiscoverToggleSectionsEnabled();
 	}
 
+	//Retrieves a token for interacting with the BFF
+	async _tokenChanged(newValue, oldValue) {
+		if(!oldValue) {
+			this.token = this.initializeToken(newValue);
+		}
+	}
 	_resetPage(pageName) {
 		const pageElement = this.shadowRoot.querySelector(`[name="${pageName}"]`);
 		if (pageElement && typeof pageElement._reset === 'function') {

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -23,7 +23,7 @@ const internalFetchMixin = (superClass) => class extends superClass {
 	constructor() {
 		super();
 	}
-	_fetchEntity(sirenLinkOrUrl, method = 'GET') {
+	async _fetchEntity(sirenLinkOrUrl, method = 'GET') {
 		if (!sirenLinkOrUrl) {
 			return;
 		}
@@ -34,11 +34,12 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			return;
 		}
 
+		const token = await this._getToken();
 		const request = new Request(url, {
 			method,
 			headers: {
 				Accept: 'application/vnd.siren+json',
-				Authorization: 'Bearer ' + window.D2L.token
+				Authorization: 'Bearer ' + token
 			},
 		});
 
@@ -50,7 +51,8 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			.fetch(request)
 			.then(this.__responseToSirenEntity.bind(this));
 	}
-	_fetchEntityWithoutDedupe(sirenLinkOrUrl, method = 'GET') {
+
+	async _fetchEntityWithoutDedupe(sirenLinkOrUrl, method = 'GET') {
 		if (!sirenLinkOrUrl) {
 			return;
 		}
@@ -61,11 +63,12 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			return;
 		}
 
+		const token = await this._getToken();
 		const request = new Request(url, {
 			method,
 			headers: {
 				Accept: 'application/vnd.siren+json',
-				Authorization: 'Bearer ' + window.D2L.token
+				Authorization: 'Bearer ' + token
 			},
 		});
 
@@ -129,7 +132,7 @@ const internalFetchMixin = (superClass) => class extends superClass {
 	}
 
 	//Globally initializes the token using the passed tokenReciever function.
-	async initializeToken(tokenGetter) {
+	async _initializeToken(tokenGetter) {
 		window.D2L.token = await tokenGetter();
 	}
 

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -117,7 +117,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 		return Promise.reject(response.status + ' ' + response.statusText);
 	}
 
-
 	async _createRequest(url, method) {
 		const token = await this._getToken();
 		const request = new Request(url, {
@@ -137,9 +136,8 @@ const internalFetchMixin = (superClass) => class extends superClass {
 	}
 
 	async _getToken() {
-		if(window.D2L.tokenPromise) {
+		if (window.D2L.tokenPromise) {
 			const token = await window.D2L.tokenPromise();
-			console.log(token);
 			return token;
 		}
 	}

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -134,7 +134,7 @@ const internalFetchMixin = (superClass) => class extends superClass {
 	}
 
 	//Any async token requirements will poll for the token until the initialization has been complete.
-	//This should be replaced with an attribute based solution when removing discover-app.
+	//This should be replaced with an attribute based solution when componentizing the project.
 	async _getToken() {
 		while (!window.D2L.token) {
 			await new Promise(resolve => setTimeout(resolve, 50));

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -129,14 +129,14 @@ const internalFetchMixin = (superClass) => class extends superClass {
 	}
 
 	//Globally initializes the token using the passed tokenReciever function.
-	async initializeToken (tokenGetter) {
+	async initializeToken(tokenGetter) {
 		window.D2L.token = await tokenGetter();
 	}
 
 	//Any async token requirements will poll for the token until the initialization has been complete.
 	//This should be replaced with an attribute based solution when removing discover-app.
 	async _getToken() {
-		while(!window.D2L.token) {
+		while (!window.D2L.token) {
 			await new Promise(resolve => setTimeout(resolve, 50));
 		}
 		return window.D2L.token;

--- a/test/mixins/fetch-mixin-test.js
+++ b/test/mixins/fetch-mixin-test.js
@@ -9,7 +9,10 @@ describe('Fetch Mixin Tests', () => {
 		bffRootResponse;
 	function SetupFetchStub(url, entity) {
 		const request = new Request(url, {
-			headers: { Accept: 'application/vnd.siren+json' },
+			headers: {
+				Accept: 'application/vnd.siren+json',
+				Authorization: 'Bearer ' + 'token'
+			},
 		});
 		fetchStub.withArgs(request)
 			.returns(Promise.resolve({


### PR DESCRIPTION
The token system has been adjusted to load from the LMS via `d2l-token-reciever`. This means that a function to retrieve the token based on the current user is assigned to `discover-app`'s `token` property. 

We can call this function and block any subcomponents attempting to retrieve the token until it has been assigned. By doing so, inner components shouldn't require behavior changes and will still get a token in a similar manner to before.

GET and POST calls have been adjusted to apply the token to the requests. This works in the context of `polymer serve` but seems to require additional work to function within BSI. That additional work is not within the scope of this story.

This story is dependent on https://github.com/Brightspace/lms/pull/2489 being approved before tokens will be received.