### PR TITLE
US120284 - Assign options and endpoint from JSON

### DIFF
--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -66,6 +66,10 @@ class DiscoveryApp extends FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerEl
 	}
 	static get properties() {
 		return {
+			options: {
+				type: String,
+				observer: '_optionsChanged'
+			},
 			page: {
 				type: String,
 				reflectToAttribute: true
@@ -79,20 +83,16 @@ class DiscoveryApp extends FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerEl
 			routeData: Object,
 			subroute: Object,
 			_promotedCoursesEnabled: {
-				type: Boolean,
-				computed: '_isPromotedCoursesEnabled()'
+				type: Boolean
 			},
 			_manageDiscover: {
-				type: Boolean,
-				computed: '_canManageDiscover()'
+				type: Boolean
 			},
 			_discoverCustomizationsEnabled: {
-				type: Boolean,
-				computed: '_isDiscoverCustomizationsEnabled()'
+				type: Boolean
 			},
 			_discoverToggleSectionsEnabled: {
-				type: Boolean,
-				computed: '_isDiscoverToggleSectionsEnabled()'
+				type: Boolean
 			}
 		};
 	}
@@ -168,6 +168,16 @@ class DiscoveryApp extends FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerEl
 		queryParams = queryParams.detail.value || {};
 		this.queryParams = queryParams;
 	}
+
+	//Assigns feature/flags/endpoint/other information from LMS.
+	_optionsChanged(optionsJSON) {
+		this._initializeOptions(optionsJSON);
+		this._promotedCoursesEnabled = this._isPromotedCoursesEnabled();
+		this._manageDiscover = this._canManageDiscover();
+		this._discoverCustomizationsEnabled = this._isDiscoverCustomizationsEnabled();
+		this._discoverToggleSectionsEnabled = this._isDiscoverToggleSectionsEnabled();
+	}
+
 	_resetPage(pageName) {
 		const pageElement = this.shadowRoot.querySelector(`[name="${pageName}"]`);
 		if (pageElement && typeof pageElement._reset === 'function') {

--- a/src/mixins/feature-mixin.js
+++ b/src/mixins/feature-mixin.js
@@ -33,6 +33,11 @@ const internalFeatureMixin = (superClass) => class extends superClass {
 	_getOptions() {
 		return window.D2L && window.D2L.frau && window.D2L.frau.options;
 	}
+
+	_initializeOptions(optionsJSON) {
+		window.D2L.frau.options = JSON.parse(optionsJSON);
+		window.D2L.bffEndpoint = window.D2L.frau.options.endpoint;
+	}
 };
 
 export const FeatureMixin = dedupingMixin(internalFeatureMixin);


### PR DESCRIPTION
Changes the options to be retrieved from a JSONified options collection provided by the LMS.

These are the same options that were previously hosted by the FRA, and includes the `bffEndpoint, userID, TelemetryEndpoint, InstanceName`, and all feature flags.

Small changes have been made to accommodate the passing of these options as a property rather than an immediately accessible hosted value.

Tested by confirming the `bffEndpoint` was utilized by all fetch requests, `canManageDiscover` was correctly assigned based on the account role and impacted the visibility of the settings button, and features were being applied as a result of the flags.