### PR TITLE
Self enrolled date will now be assigned upon self enrollment

### DIFF
--- a/src/components/course-summary.js
+++ b/src/components/course-summary.js
@@ -659,6 +659,7 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 								this._enrollmentDialogMessage = this.localize('enrollmentMessageSuccess', 'title', this.courseTitle);
 							}
 							this.organizationHomepage = organizationHomepage;
+							this.selfEnrolledDate = Date.now();
 						});
 				})
 				.catch(() => {


### PR DESCRIPTION
The `enrollment pending` message depends on selfEnrolledDate  existing to confirm that the user has self enrolled. If it doesn't exist, you get the `No Current Access` message, as there is no date of enrollment. You can see this in line 618-620.

Normally, `selfEnrolledDate` is passed in from the course entity by the parent component `discovery-course.js`. 
If you self enroll, there was no opportunity for the  `selfEnrolledDate` to be assigned from the parent. It will therefore be null.
You will get the correct message if you refresh the page immediately after self-enrolling, as in that case, `selfEnrolledDate` is retrieved and correctly assigned.

The solution is to just assign the self enrollment date to date.Now() once the enrollment is confirmed to have gone through. This will ensure the date exists, which will cause the pending message to appear in this scenario.

I attempted to retrieve `selfEnrolledDate` immediately from the loaded `organizationEntity` but it seems to only be available from the courseEntity information passed by the parent component. Since the pending calculation also compares using date.Now() I assume it should be safe to use here as well, and is much easier than pulling in another entity just for that information.

On another note, this might have just always been broken. Im not sure how this would be ALS's fault 🤔 