### PR TITLE
Bhamelin/de41059 fix pending enrollment

### DIFF
--- a/src/components/course-summary.js
+++ b/src/components/course-summary.js
@@ -659,6 +659,7 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 								this._enrollmentDialogMessage = this.localize('enrollmentMessageSuccess', 'title', this.courseTitle);
 							}
 							this.organizationHomepage = organizationHomepage;
+							this.selfEnrolledDate = Date.now();
 						});
 				})
 				.catch(() => {

--- a/test/components/course-summary-test.js
+++ b/test/components/course-summary-test.js
@@ -708,7 +708,7 @@ describe('course-summary', () => {
 		});
 	});
 
-	describe('enrolled by user but then removed by Admin / timed out', () => {
+	describe('enrolled by user but then removed by Admin / pending enrollmentt', () => {
 		before(done => {
 			component = fixture('course-summary-basic-fixture');
 			setComponentForEnrollment({ component, enrolled: false });

--- a/test/components/course-summary-test.js
+++ b/test/components/course-summary-test.js
@@ -708,10 +708,10 @@ describe('course-summary', () => {
 		});
 	});
 
-	describe('enrolled by user but then removed by Admin', () => {
+	describe('enrolled by user but then removed by Admin / timed out', () => {
 		before(done => {
 			component = fixture('course-summary-basic-fixture');
-			setComponentForEnrollment({ component, enrolled: false }, new Date(Date.now() - 1000 * 60 * 11).toString());
+			setComponentForEnrollment({ component, enrolled: false });
 			setComponentHomepage({ component, homepage: false });
 			afterNextRender(component, done);
 		});
@@ -753,6 +753,9 @@ describe('course-summary', () => {
 					// Enroll button is hidden
 					expect(enrollButton.style.display).to.equal('none');
 
+					//Self enrollment date has been assigned
+					expect(component.selfEnrolledDate).to.not.equal(undefined);
+
 					// Click the open course button
 					openCourseButton.click();
 
@@ -761,17 +764,39 @@ describe('course-summary', () => {
 						const dialog = component.$$('#discovery-course-summary-enroll-dialog');
 						expect(dialog.opened).to.equal(true);
 						const dialogMessage = component.$$('.discovery-course-summary-dialog-content-container').innerHTML;
-						expect(dialogMessage).to.include('You have been un-enrolled by an Administrator, contact your Administrator in order to enroll again.');
+						expect(dialogMessage).to.include('Your enrollment to this course is pending, check back soon to access this course.');
 
 						// Open Course button still exists and is displayed
 						const openCourseButton = component.$$('#discovery-course-summary-open-course');
 						expect(openCourseButton).to.exist;
 						expect(openCourseButton.style.display).to.not.equal('none');
 
-						// Set organization-href to something that will now return a homepage
-						component.setAttribute('organization-href', testOrganizationHref);
+						//Close the dialog
+						dialog.closed = true;
+
+						//Set self enrollment date to a time that is greater than 10 minutes in the past
+						component.setAttribute('self-enrolled-date', new Date(Date.now() - 1000 * 60 * 11) )
+
+						// Click the open course button a second time
+						openCourseButton.click();
+
+						// Timeout un-enrolled dialog is shown
 						afterNextRender(component, () => {
-							openCourseButton.click();
+							const dialog = component.$$('#discovery-course-summary-enroll-dialog');
+							expect(dialog.opened).to.equal(true);
+							const dialogMessage = component.$$('.discovery-course-summary-dialog-content-container').innerHTML;
+							expect(dialogMessage).to.include('You have been un-enrolled by an Administrator, contact your Administrator in order to enroll again.');
+
+							// Open Course button still exists and is displayed
+							const openCourseButton = component.$$('#discovery-course-summary-open-course');
+							expect(openCourseButton).to.exist;
+							expect(openCourseButton.style.display).to.not.equal('none');
+
+							// Set organization-href to something that will now return a homepage
+							component.setAttribute('organization-href', testOrganizationHref);
+							afterNextRender(component, () => {
+								openCourseButton.click();
+							});
 						});
 					});
 				}, timeToExhaustRetriesInMs);
@@ -779,7 +804,7 @@ describe('course-summary', () => {
 		});
 	});
 
-	describe('enrolled by user but then removed by Admin without selfEnrolledDate', () => {
+	describe('enrolled by user but then removed by Admin, selfEnrollDate is null', () => {
 		before(done => {
 			component = fixture('course-summary-basic-fixture');
 			setComponentForEnrollment({ component, enrolled: false });
@@ -827,7 +852,10 @@ describe('course-summary', () => {
 					// Click the open course button
 					openCourseButton.click();
 
-					// Pending dialog is shown
+					//Set self enrollment date to null
+					component.setAttribute('self-enrolled-date', null )
+
+					// unenrolled dialog is shown
 					afterNextRender(component, () => {
 						const dialog = component.$$('#discovery-course-summary-enroll-dialog');
 						expect(dialog.opened).to.equal(true);


### PR DESCRIPTION
This PR resolves the issue where self-enrolling in a course and immediately pressing 'open-course' would cause the 'unenrolled' message to appear instead of the 'enrollment pending' message.

The `selfEnrolledDate ` property was only assigned via initialization. Consequently, when self enrolling, this property would remain null. This property is used to determine the time since enrollment, and which message to appear if the course cannot currently be accessed.
The 'enrollment pending' message only appears for 10 minutes, and then times out to display the 'unenrolled' message instead. Because `selfEnrolledDate` is null, it cannot check the 10 minute timeframe and therefore assumes the user was unenrolled.

This PR fixes the above issue by assigning `selfEnrolledDate` to `date.now()` immediately upon confirmation of enrollment, to ensure the 10 minute window performs correctly.

Tests have been updated to confirm the pending message appears within the 10 minute window, and that a null `selfEnrolledDate` will still lead to an 'unenrolled' message.
