### PR TITLE
Clabatt/us120287 fix bsi app routing

### DIFF
--- a/src/components/course-summary.js
+++ b/src/components/course-summary.js
@@ -348,7 +348,7 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 					<div id="discovery-course-summary-card" class="discovery-course-summary-card">
 						<div class="discovery-course-summary-breadcrumbs">
 							<d2l-breadcrumbs>
-								<d2l-breadcrumb href="[[_homeHref]]" text="[[localize('discover')]]" aria-label="[[localize('backToDiscover')]]"></d2l-breadcrumb>
+								<d2l-breadcrumb href="[[_getHomeHref()]]" text="[[localize('discover')]]" aria-label="[[localize('backToDiscover')]]"></d2l-breadcrumb>
 							</d2l-breadcrumbs>
 						</div>
 
@@ -518,10 +518,6 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 			selfEnrolledDate: String,
 			_enrollmentDialogHeader: String,
 			_enrollmentDialogMessage: String,
-			_homeHref: {
-				type: String,
-				computed: '_getHomeHref()'
-			},
 			startDate: String,
 			startDateIsoFormat: String,
 			_startDateIsFuture: {

--- a/src/components/course-summary.js
+++ b/src/components/course-summary.js
@@ -16,7 +16,6 @@ import '@brightspace-ui/core/components/icons/icon.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import 'd2l-typography/d2l-typography.js';
 import 'fastdom/fastdom.js';
-
 import { FetchMixin } from '../mixins/fetch-mixin.js';
 import { LocalizeMixin } from '../mixins/localize-mixin.js';
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
@@ -349,7 +348,7 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 					<div id="discovery-course-summary-card" class="discovery-course-summary-card">
 						<div class="discovery-course-summary-breadcrumbs">
 							<d2l-breadcrumbs>
-								<d2l-breadcrumb on-click="_navigateToHome" href="[[_homeHref]]" text="[[localize('discover')]]" aria-label="[[localize('backToDiscover')]]"></d2l-breadcrumb>
+								<d2l-breadcrumb href="[[_homeHref]]" text="[[localize('discover')]]" aria-label="[[localize('backToDiscover')]]"></d2l-breadcrumb>
 							</d2l-breadcrumbs>
 						</div>
 
@@ -734,7 +733,7 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 	}
 
 	_getHomeHref() {
-		return this.valenceHomeHref();
+		return this.routeLocations().home();
 	}
 
 	_startDateIsFutureComputed(startDateIsoFormat) {

--- a/src/components/discover-settings-breadcrumbs-lit.js
+++ b/src/components/discover-settings-breadcrumbs-lit.js
@@ -1,6 +1,5 @@
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumb.js';
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumbs.js';
-
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
@@ -15,27 +14,8 @@ class DiscoverSettingsBreadcrumbsLit extends LocalizeMixin(RouteLocationsMixin(L
 	render() {
 		return html `
 		<d2l-breadcrumbs compact>
-			<d2l-breadcrumb @click="${this._navigateToHome}" href="${this._getHomeHref()}" text="${this.localize('backToDiscover')}"></d2l-breadcrumb>
+			<d2l-breadcrumb href="${this.routeLocations().home()}" text="${this.localize('backToDiscover')}"></d2l-breadcrumb>
 		</d2l-breadcrumbs>`;
-	}
-
-	_navigateToHome(e) {
-		if (e) {
-			e.preventDefault();
-		}
-
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: this.routeLocations().home(),
-				resetPages: ['settings']
-			},
-			bubbles: true,
-			composed: true
-		}));
-	}
-
-	_getHomeHref() {
-		return this.valenceHomeHref();
 	}
 }
 

--- a/src/components/discover-settings-promoted-content.js
+++ b/src/components/discover-settings-promoted-content.js
@@ -19,8 +19,10 @@ import { entityFactory, dispose } from 'siren-sdk/src/es6/EntityFactory';
 import { OrganizationCollectionEntity } from 'siren-sdk/src/organizations/OrganizationCollectionEntity';
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { DiscoverSettingsMixin } from '../mixins/discover-settings-mixin.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import './loading-skeleton.js';
 
-class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocationsMixin(FetchMixin(LocalizeMixin(LitElement)))) {
+class DiscoverSettingsPromotedContent extends SkeletonMixin(DiscoverSettingsMixin(RouteLocationsMixin(FetchMixin(LocalizeMixin(LitElement))))) {
 
 	static async getLocalizeResources(langs) {
 		return getLocalizeResources(langs);
@@ -129,27 +131,16 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 				margin-top: .5rem;
 				margin-bottom: .5rem;
 			}
-			.d2l-discover-list-item-pulse-placeholder {
-				animation: pulsingAnimation 1.8s linear infinite;
-				height: 100%;
-				width: 100%;
-				border-radius: 4px;
+			.img-skeleton {
+				width: 180px;
+				height: 76.66px;
 			}
-			.d2l-discover-list-item-content-placeholder {
-				flex-grow: 1;
-				display: flex;
-				flex-direction: column;
-				width: 100%;
+			.discovery-featured-placeholder-container {
+				width: 100%
 			}
-			.d2l-discover-list-item-image-placeholder {
-				width: 90px;
-				height: 38.33px;
-				border: 1px solid var(--d2l-color-gypsum);
-			}
-			.d2l-discover-list-item-category-placeholder {
-				display: block;
-				height: 0.95rem;
-				margin: 0.3rem 0;
+			.discovery-featured-title-placeholder {
+				height: 1.1rem;
+				margin: 0.17rem 0rem;
 				width: 50%;
 			}
 		`];
@@ -206,20 +197,23 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 	}
 
 	_renderFeaturedSection() {
-		const loadingPlaceholder = this._renderLoadingPlaceholder();
 		return html`
 			${this._promotedActivities.length > 0 ? html`
 				<d2l-list class="discover-featured-list">
 					${this._promotedActivities.map((activity) => html`
-						${!activity.loaded ? html`
-							${loadingPlaceholder}
-						` : html``}
-						<d2l-list-item ?hidden="${!activity.loaded}">
-							<d2l-organization-image href="${activity.organizationUrl}" slot="illustration" token="${this.token}"></d2l-organization-image>
-							<d2l-organization-name href="${activity.organizationUrl}" token="${this.token}" @d2l-organization-accessible="${(e) => this._handleSavedOrgAccessible(e, activity)}"></d2l-organization-name>
-							<div slot="actions">
-							<d2l-button-icon text="${this.localize('removeFromFeatured', 'course', activity.organizationName)}" icon="tier1:close-default" @click="${(() => this._removeFromFeatured(activity.organizationUrl))}"></d2l-button-icon>
-							</div>
+						<d2l-list-item>
+							<d2l-organization-image href="${activity.organizationUrl}" slot="illustration" token="${this.token}" class="img-skeleton" ?skeleton="${!activity.loaded}"></d2l-organization-image>
+							<d2l-organization-name href="${activity.organizationUrl}" token="${this.token}" ?hidden="${!activity.loaded}" @d2l-organization-accessible="${(e) => this._handleSavedOrgAccessible(e, activity)}"></d2l-organization-name>
+
+							${activity.loaded ? html`
+								<div slot="actions">
+									<d2l-button-icon text="${this.localize('removeFromFeatured', 'course', activity.organizationName)}" icon="tier1:close-default" @click="${(() => this._removeFromFeatured(activity.organizationUrl))}"></d2l-button-icon>
+								</div>
+							` : html`
+								<div class="discovery-featured-placeholder-container">
+									<loading-skeleton class="discovery-featured-title-placeholder"></loading-skeleton>
+								</div>
+							`}
 						</d2l-list-item>
 					`)}
 				</d2l-list>
@@ -274,19 +268,6 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 					<d2l-button @click=${this._loadMoreCandidates}>${this.localize('loadMore')}</d2l-button>
 				`}
 			`}
-		`;
-	}
-
-	_renderLoadingPlaceholder() {
-		return html`
-			<d2l-list-item>
-				<div slot="illustration" class="d2l-discover-list-item-image-placeholder">
-					<div class="d2l-discover-list-item-pulse-placeholder"></div>
-				</div>
-				<div class="d2l-discover-list-item-content-placeholder">
-					<div class="d2l-discover-list-item-pulse-placeholder d2l-discover-list-item-category-placeholder"></div>
-				</div>
-			</d2l-list-item>
 		`;
 	}
 

--- a/src/components/discover-settings-toast.js
+++ b/src/components/discover-settings-toast.js
@@ -1,11 +1,10 @@
 'use strict';
 import '@brightspace-ui/core/components/alert/alert-toast.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
-import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { getLocalizeResources } from '../localization.js';
 
-class DiscoverSettingsToast extends LocalizeMixin(RouteLocationsMixin(LitElement)) {
+class DiscoverSettingsToast extends LocalizeMixin(LitElement) {
 
 	render() {
 		return html`

--- a/src/components/home-all-section.js
+++ b/src/components/home-all-section.js
@@ -46,7 +46,7 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 						<d2l-link
 							aria-label$="[[localize('viewAllLabel')]]"
 							class="activity-card-list-header-view-all-link"
-							href="[[_viewAllHref]]">
+							href="[[_getViewAllHref()]]">
 							[[localize('viewAll')]]
 						</d2l-link>
 					</div>
@@ -97,11 +97,7 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 			showSemesterName: {
 				type: Boolean,
 			},
-			token: String,
-			_viewAllHref: {
-				type: String,
-				computed: '_getViewAllHref()'
-			}
+			token: String
 		};
 	}
 

--- a/src/components/home-all-section.js
+++ b/src/components/home-all-section.js
@@ -37,10 +37,14 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 						font-size: 0.7rem;
 					}
 				}
+
+				[hidden] {
+					display: none !important;
+				}
 			</style>
 			
-			<div class="d2l-typography">
-				<div class="discovery-home-recently-updated-container" hidden$="[[!_hasCourses(_recentlyUpdatedItems)]]">
+			<div class="d2l-typography" hidden$="[[!_hasCourses(_recentlyUpdatedItems)]]">
+				<div class="discovery-home-recently-updated-container">
 					<div class="activity-card-list-header">
 						<h2 class="d2l-heading-2" aria-label$="[[localize('all')]]">[[localize('all')]]</h2>
 						<d2l-link

--- a/src/components/home-all-section.js
+++ b/src/components/home-all-section.js
@@ -68,7 +68,7 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 			</div>
 		`;
 	}
-	
+
 	static get properties() {
 		return {
 			_pageSize: {

--- a/src/components/home-all-section.js
+++ b/src/components/home-all-section.js
@@ -4,24 +4,24 @@ import '@brightspace-ui/core/components/button/button.js';
 import 'd2l-typography/d2l-typography.js';
 import '../components/activity-card-list.js';
 import '../styles/discovery-styles.js';
-
 import { FetchMixin } from '../mixins/fetch-mixin.js';
 import { LocalizeMixin } from '../mixins/localize-mixin.js';
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 
 class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(PolymerElement))) {
 	static get template() {
-
 		return html`
 			<style include="discovery-styles">
 				.discovery-home-recently-updated-container {
 					display: flex;
 					flex-direction: column;
 				}
+
 				.discovery-home-load-more-button {
 					margin-top: 0.5rem;
 					width: 100%;
 				}
+
 				.activity-card-list-header {
 					display: flex;
 					justify-content: space-between;
@@ -38,6 +38,7 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 					}
 				}
 			</style>
+			
 			<div class="d2l-typography">
 				<div class="discovery-home-recently-updated-container" hidden$="[[!_hasCourses(_recentlyUpdatedItems)]]">
 					<div class="activity-card-list-header">
@@ -45,8 +46,7 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 						<d2l-link
 							aria-label$="[[localize('viewAllLabel')]]"
 							class="activity-card-list-header-view-all-link"
-							href="javascript:void(0)"
-							on-click="_navigateToViewAll">
+							href="[[_viewAllHref]]">
 							[[localize('viewAll')]]
 						</d2l-link>
 					</div>
@@ -68,6 +68,7 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 			</div>
 		`;
 	}
+	
 	static get properties() {
 		return {
 			_pageSize: {
@@ -96,7 +97,11 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 			showSemesterName: {
 				type: Boolean,
 			},
-			token: String
+			token: String,
+			_viewAllHref: {
+				type: String,
+				computed: '_getViewAllHref()'
+			}
 		};
 	}
 
@@ -118,16 +123,6 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 
 	_hasCourses(_recentlyUpdatedItems) {
 		return Array.isArray(_recentlyUpdatedItems) && _recentlyUpdatedItems.length > 0;
-	}
-
-	_navigateToViewAll() {
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: this.routeLocations().search('', { sort: 'relevant' })
-			},
-			bubbles: true,
-			composed: true
-		}));
 	}
 
 	_getRecentlyUpdatedCourses() {
@@ -228,6 +223,10 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 	_recentlyUpdatedItemsPageTotalObserver(recentlyUpdatedItemsPage, recentlyUpdatedItemsTotal) {
 		this._recentlyUpdatedItemsHasMore =
 			((recentlyUpdatedItemsPage + 1) * this._pageSize) < recentlyUpdatedItemsTotal;
+	}
+
+	_getViewAllHref() {
+		return this.routeLocations().search('', { sort: 'relevant' });
 	}
 }
 

--- a/src/components/home-header.js
+++ b/src/components/home-header.js
@@ -111,7 +111,7 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 				<div class="discovery-home-header-container">
 					<div>
 						<h1 class="d2l-heading-1 discovery-home-header-d2l-heading-1">
-							<a class="discovery-home-header-clickable" href="[[_homeHref]]">[[localize('discover')]]</a>
+							<a class="discovery-home-header-clickable" href="[[_getHomeHref()]]">[[localize('discover')]]</a>
 						</h1>
 					</div>
 					<div class="discovery-home-header-search-container">
@@ -124,7 +124,7 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 						</d2l-input-search>
 						<d2l-link
 							class="discovery-home-header-browse-all-link"
-							href="[[_browseAllHref]]">
+							href="[[_getBrowseAllHref()]]">
 							[[localize('browseAllContent')]]
 						</d2l-link>
 					</div>
@@ -150,15 +150,7 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			query: String,
 			searchInput: Object,
 			showSettingsButton: Boolean,
-			resetPage: String, //The app name of a page to reset upon navigation
-			_homeHref: {
-				type: String,
-				computed: '_getHomeHref()'
-			},
-			_browseAllHref: {
-				type: String,
-				computed: '_getBrowseAllHref()'
-			}
+			resetPage: String //The app name of a page to reset upon navigation
 		};
 	}
 

--- a/src/components/home-header.js
+++ b/src/components/home-header.js
@@ -3,7 +3,6 @@ import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 import '@brightspace-ui/core/components/link/link.js';
 import 'd2l-typography/d2l-typography.js';
-
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { LocalizeMixin } from '../mixins/localize-mixin.js';
 
@@ -29,6 +28,8 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 
 				.discovery-home-header-clickable {
 					cursor: pointer;
+					text-decoration: none;
+					color: var(--d2l-color-ferrite);
 				}
 
 				.discovery-home-header-search-container {
@@ -109,8 +110,8 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			<div class="d2l-typography">
 				<div class="discovery-home-header-container">
 					<div>
-						<h1 class="d2l-heading-1 discovery-home-header-d2l-heading-1" on-click="_navigateToHome">
-							<span class="discovery-home-header-clickable">[[localize('discover')]]</span>
+						<h1 class="d2l-heading-1 discovery-home-header-d2l-heading-1">
+							<a class="discovery-home-header-clickable" href="[[_homeHref]]">[[localize('discover')]]</a>
 						</h1>
 					</div>
 					<div class="discovery-home-header-search-container">
@@ -123,8 +124,7 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 						</d2l-input-search>
 						<d2l-link
 							class="discovery-home-header-browse-all-link"
-							href="javascript:void(0)"
-							on-click="_navigateToBrowseAll">
+							href="[[_browseAllHref]]">
 							[[localize('browseAllContent')]]
 						</d2l-link>
 					</div>
@@ -139,30 +139,39 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			</div>
 		`;
 	}
+
 	constructor() {
 		super();
 		this.query = '';
 	}
+
 	static get properties() {
 		return {
 			query: String,
 			searchInput: Object,
 			showSettingsButton: Boolean,
-			resetPage: String //The app name of a page to reset upon navigation
+			resetPage: String, //The app name of a page to reset upon navigation
+			_homeHref: {
+				type: String,
+				computed: '_getHomeHref()'
+			},
+			_browseAllHref: {
+				type: String,
+				computed: '_getBrowseAllHref()'
+			}
 		};
 	}
+
 	ready() {
 		super.ready();
 		this.searchInput = this.shadowRoot.querySelector('#discovery-home-header-search-input');
 		if (this.searchInput) {
 			this.searchInput.addEventListener('d2l-input-search-searched', (e) => {
 				if (e && e.detail) {
-					const query = e.detail.value;
+					const query = e.detail.value.trim();
 					this.dispatchEvent(new CustomEvent('navigate', {
 						detail: {
-							path: this.routeLocations().search(query ? query.trim() : '', {
-								sort: 'relevant'
-							})
+							path: this.routeLocations().search(query, { sort: 'relevant' })
 						},
 						bubbles: true,
 						composed: true,
@@ -171,34 +180,17 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			});
 		}
 	}
+
 	clear() {
 		this.query = '';
 		this.searchInput.value = '';
 		this.searchInput._setLastSearchValue('');
 	}
+
 	focusOnInput() {
 		this.searchInput.focus();
 	}
-	_navigateToHome() {
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: this.routeLocations().navLink(),
-				resetPages: [this.resetPage]
-			},
-			bubbles: true,
-			composed: true,
-		}));
-	}
-	_navigateToBrowseAll() {
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: this.routeLocations().search('', { sort: 'relevant' }),
-				resetPages: [this.resetPage]
-			},
-			bubbles: true,
-			composed: true
-		}));
-	}
+
 	_navigateToSettings() {
 		this.dispatchEvent(new CustomEvent('navigate', {
 			detail: {
@@ -208,6 +200,14 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			bubbles: true,
 			composed: true
 		}));
+	}
+
+	_getHomeHref() {
+		return this.routeLocations().home();
+	}
+
+	_getBrowseAllHref() {
+		return this.routeLocations().search('', { sort: 'relevant' });
 	}
 }
 

--- a/src/components/home-list-section.js
+++ b/src/components/home-list-section.js
@@ -12,8 +12,8 @@ class HomeListSection extends EntityMixinLit(RouteLocationsMixin(LitElement)) {
 	render() {
 		return html`
 			<style include="discovery-styles"></style>
-			<div class="d2l-typography">
-				<div class="discovery-home-list-section-container" ?hidden="${!this._hasCourses(this._sortedCourses)}">
+			<div class="d2l-typography" ?hidden="${!this._hasCourses(this._sortedCourses)}">
+				<div class="discovery-home-list-section-container">
 					<div class="activity-card-list-header">
 						<h2 class="d2l-heading-2" aria-label="${this.sectionName}">${this.sectionName}</h2>
 						<d2l-link

--- a/src/components/home-list-section.js
+++ b/src/components/home-list-section.js
@@ -3,7 +3,6 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { heading2Styles, bodyCompactStyles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import './activity-card-list.js';
 import '../styles/discovery-styles.js';
-
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { OrganizationCollectionEntity } from 'siren-sdk/src/organizations/OrganizationCollectionEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
@@ -20,8 +19,7 @@ class HomeListSection extends EntityMixinLit(RouteLocationsMixin(LitElement)) {
 						<d2l-link
 							aria-label="${this.linkLabel}"
 							class="activity-card-list-header-view-all-link"
-							href="javascript:void(0)"
-							@click="${this._navigateToViewAll}">
+							href="${this.routeLocations().search('', { sort: this.sort })}">
 							${this.linkName}
 						</d2l-link>
 					</div>
@@ -146,16 +144,6 @@ class HomeListSection extends EntityMixinLit(RouteLocationsMixin(LitElement)) {
 				composed: true
 			}));
 		}
-	}
-
-	_navigateToViewAll() {
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: this.routeLocations().search('', { sort: this.sort })
-			},
-			bubbles: true,
-			composed: true
-		}));
 	}
 }
 

--- a/src/components/search-header.js
+++ b/src/components/search-header.js
@@ -71,7 +71,7 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 				<div class="discovery-search-header-container">
 					<div class="discovery-search-header-nav-container">
 						<d2l-breadcrumbs class="discovery-search-header-breadcrumb" compact>
-							<d2l-breadcrumb href="[[_homeHref]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
+							<d2l-breadcrumb href="[[_getHomeHref()]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
 						</d2l-breadcrumbs>
 					</div>
 
@@ -97,10 +97,6 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			query: String,
 			searchInput: Object,
 			sortParameter: String,
-			_homeHref: {
-				type: String,
-				computed: '_getHomeHref()'
-			},
 			page: Number
 		};
 	}

--- a/src/components/search-header.js
+++ b/src/components/search-header.js
@@ -147,7 +147,7 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 	focusOnInput() {
 		this.searchInput.focus();
 	}
-	
+
 	_getHomeHref() {
 		return this.routeLocations().home();
 	}

--- a/src/components/search-header.js
+++ b/src/components/search-header.js
@@ -4,7 +4,6 @@ import '@brightspace-ui/core/components/breadcrumbs/breadcrumb.js';
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumbs.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 import 'd2l-typography/d2l-typography.js';
-
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { LocalizeMixin } from '../mixins/localize-mixin.js';
 
@@ -72,7 +71,7 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 				<div class="discovery-search-header-container">
 					<div class="discovery-search-header-nav-container">
 						<d2l-breadcrumbs class="discovery-search-header-breadcrumb" compact>
-							<d2l-breadcrumb on-click="_navigateToHome" href="[[_homeHref]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
+							<d2l-breadcrumb href="[[_homeHref]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
 						</d2l-breadcrumbs>
 					</div>
 
@@ -92,6 +91,7 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 		super();
 		this.query = '';
 	}
+
 	static get properties() {
 		return {
 			query: String,
@@ -104,11 +104,13 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			page: Number
 		};
 	}
+
 	static get observers() {
 		return [
 			'queryObserver(query)'
 		];
 	}
+
 	ready() {
 		super.ready();
 		this.searchInput = this.shadowRoot.querySelector('#discovery-search-header-search-input');
@@ -119,9 +121,7 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 					if (query !== this.query || this.page !== 0) {
 						this.dispatchEvent(new CustomEvent('navigate', {
 							detail: {
-								path: this.routeLocations().search(query, {
-									sort: this.sortParameter
-								}),
+								path: this.routeLocations().search(query, { sort: this.sortParameter }),
 								resetPages: ['search']
 							},
 							bubbles: true,
@@ -132,37 +132,30 @@ class SearchHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			});
 		}
 	}
+
 	clear() {
 		this.query = '';
 		this.searchInput.value = '';
 		this.searchInput._setLastSearchValue('');
 	}
+
 	showClear(query) {
 		this.searchInput.value = query;
 		this.searchInput._setLastSearchValue(query);
 	}
+
 	focusOnInput() {
 		this.searchInput.focus();
 	}
-	_navigateToHome(e) {
-		if (e) {
-			e.preventDefault();
-		}
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: this.routeLocations().navLink(),
-			},
-			bubbles: true,
-			composed: true,
-		}));
-		this.clear();
-	}
+	
 	_getHomeHref() {
-		return this.valenceHomeHref();
+		return this.routeLocations().home();
 	}
+
 	queryObserver(query) {
 		this.query = query || '';
 	}
+
 	reset() {
 		this.searchInput.value = this.query;
 	}

--- a/src/components/search-results.js
+++ b/src/components/search-results.js
@@ -216,11 +216,7 @@ class SearchResults extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 				type: Boolean,
 				value: false
 			},
-			token: String,
-			_browseAllHref: {
-				type: String,
-				computed: '_getBrowseAllHref()'
-			}
+			token: String
 		};
 	}
 
@@ -488,7 +484,7 @@ class SearchResults extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 				noResultsMessage = this.localize(
 					'noResultsMessage',
 					'linkStart',
-					'<d2l-link href="[[_browseAllHref]]" id="discovery-search-results-browse-all">',
+					'<d2l-link href="[[_getBrowseAllHref()]]" id="discovery-search-results-browse-all">',
 					'linkEnd',
 					'</d2l-link>');
 			}

--- a/src/components/search-results.js
+++ b/src/components/search-results.js
@@ -349,7 +349,6 @@ class SearchResults extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 	}
 
 	_paginationPageChanged(e) {
-
 		this._navigateToPage(e.detail.page);
 	}
 
@@ -513,7 +512,7 @@ class SearchResults extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 		}
 	}
 
-	_getBrowseAllHref(){
+	_getBrowseAllHref() {
 		return this.routeLocations().search('', { sort: this.sortParameter });
 	}
 }

--- a/src/components/search-sidebar.js
+++ b/src/components/search-sidebar.js
@@ -27,21 +27,12 @@ class SearchSidebar extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 				<div class="discovery-search-sidebar-container">
 					<div class="discovery-search-sidebar-nav-container">
 						<d2l-breadcrumbs compact>
-							<d2l-breadcrumb href="[[_homeHref]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
+							<d2l-breadcrumb href="[[_getHomeHref()]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
 						</d2l-breadcrumbs>
 					</div>
 				</div>
 			</div>
 		`;
-	}
-
-	static get properties() {
-		return {
-			_homeHref: {
-				type: String,
-				computed: '_getHomeHref()'
-			}
-		};
 	}
 
 	_getHomeHref() {

--- a/src/components/search-sidebar.js
+++ b/src/components/search-sidebar.js
@@ -3,7 +3,6 @@ import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumb.js';
 import '@brightspace-ui/core/components/breadcrumbs/breadcrumbs.js';
 import 'd2l-typography/d2l-typography.js';
-
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { LocalizeMixin } from '../mixins/localize-mixin.js';
 
@@ -23,17 +22,19 @@ class SearchSidebar extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 					font-size: 14px;
 			}
 			</style>
+			
 			<div>
 				<div class="discovery-search-sidebar-container">
 					<div class="discovery-search-sidebar-nav-container">
 						<d2l-breadcrumbs compact>
-							<d2l-breadcrumb on-click="_navigateToHome" href="[[_homeHref]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
+							<d2l-breadcrumb href="[[_homeHref]]" text="[[localize('backToDiscover')]]"></d2l-breadcrumb>
 						</d2l-breadcrumbs>
 					</div>
 				</div>
 			</div>
 		`;
 	}
+
 	static get properties() {
 		return {
 			_homeHref: {
@@ -42,18 +43,9 @@ class SearchSidebar extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			}
 		};
 	}
-	_navigateToHome(e) {
-		e.preventDefault();
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: this.routeLocations().navLink(),
-			},
-			bubbles: true,
-			composed: true,
-		}));
-	}
+
 	_getHomeHref() {
-		return this.valenceHomeHref();
+		return this.routeLocations().home();
 	}
 }
 

--- a/src/discovery-404.js
+++ b/src/discovery-404.js
@@ -18,18 +18,9 @@ class Discovery404 extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			
 			<div>
 				<span>[[localize('message404')]]</span>
-				<d2l-link href="[[_homeHref]]">[[localize('navigateHome')]]</d2l-link>
+				<d2l-link href="[[_getHomeHref()]]">[[localize('navigateHome')]]</d2l-link>
 			</div>
 		`;
-	}
-
-	static get properties() {
-		return {
-			_homeHref: {
-				type: String,
-				computed: '_getHomeHref()'
-			}
-		};
 	}
 
 	_getHomeHref() {

--- a/src/discovery-404.js
+++ b/src/discovery-404.js
@@ -1,8 +1,10 @@
 'use strict';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { LocalizeMixin } from './mixins/localize-mixin.js';
+import { RouteLocationsMixin } from './mixins/route-locations-mixin.js';
+import '@brightspace-ui/core/components/link/link.js';
 
-class Discovery404 extends LocalizeMixin(PolymerElement) {
+class Discovery404 extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 	static get template() {
 		return html`
 	  		<style>
@@ -13,17 +15,25 @@ class Discovery404 extends LocalizeMixin(PolymerElement) {
 					padding: 10px;
 				}
 	  		</style>
-			<p>[[localize('message404')]] <a href="javascript:void(0)" on-click="_goToHome">[[localize('navigateHome')]]</a></p>
+			
+			<div>
+				<span>[[localize('message404')]]</span>
+				<d2l-link href="[[_homeHref]]">[[localize('navigateHome')]]</d2l-link>
+			</div>
 		`;
 	}
-	_goToHome() {
-		this.dispatchEvent(new CustomEvent('navigate', {
-			detail: {
-				path: '/d2l/le/discovery/view/'
-			},
-			bubbles: true,
-			composed: true,
-		}));
+
+	static get properties() {
+		return {
+			_homeHref: {
+				type: String,
+				computed: '_getHomeHref()'
+			}
+		};
+	}
+	
+	_getHomeHref() {
+		return this.routeLocations().home();
 	}
 }
 

--- a/src/discovery-404.js
+++ b/src/discovery-404.js
@@ -31,7 +31,7 @@ class Discovery404 extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 			}
 		};
 	}
-	
+
 	_getHomeHref() {
 		return this.routeLocations().home();
 	}

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -108,20 +108,26 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 	constructor() {
 		super();
 
-		if (window.location.pathname && window.location.pathname.includes('search')) {
-			this.page = 'search';
-		} else if (window.location.pathname && window.location.pathname.includes('settings')) {
-			this.page = 'settings';
-		} else if (window.location.pathname && window.location.pathname.includes('course')) {
-			this.page = 'course';
-		} else if (window.location.pathname && window.location.pathname.includes('404')) {
-			this.page = '404';
+		const path = window.location.pathname;
+		if (path) {
+			if (path === this.routeLocations().settings()) {
+				this.page = 'settings';
+			} else if (path === this.routeLocations().noQuerySearch()) {
+				this.page = 'search';
+			} else if (path.includes(this.routeLocations().course(''))) {
+				this.page = 'course';
+			} else if (path === this.routeLocations().home() || path === this.routeLocations().navLink()) {
+				this.page = 'home';
+			} else {
+				this.page = '404';
+			}
 		} else {
-			this.page = 'home';
+			this.page = '404';
 		}
 
 		this._routeDataChangedHandled = this._routeDataChanged.bind(this);
 	}
+
 	ready() {
 		super.ready();
 		this.addEventListener('navigate', this._navigate);

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -107,6 +107,19 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 
 	constructor() {
 		super();
+
+		if (window.location.pathname && window.location.pathname.includes('search')) {
+			this.page = 'search';
+		} else if (window.location.pathname && window.location.pathname.includes('settings')) {
+			this.page = 'settings';
+		} else if (window.location.pathname && window.location.pathname.includes('course')) {
+			this.page = 'course';
+		} else if (window.location.pathname && window.location.pathname.includes('404')) {
+			this.page = '404';
+		} else {
+			this.page = 'home';
+		}
+
 		this._routeDataChangedHandled = this._routeDataChanged.bind(this);
 	}
 	ready() {
@@ -131,7 +144,7 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 				});
 			}
 			if (e.detail.path) {
-				this.set('route.path', e.detail.path);
+				window.location.href = e.detail.path;
 			}
 		}
 	}

--- a/src/discovery-settings.js
+++ b/src/discovery-settings.js
@@ -58,18 +58,18 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 					${!this._settingsLoaded ? html`
 						<d2l-input-checkbox skeleton>${this.localize('showCourseCode')}</d2l-input-checkbox>
 						<d2l-input-checkbox skeleton>${this.localize('showSemester')}</d2l-input-checkbox>
-					` : html``}
-
-					<div class="discover-customization-settings" ?hidden="${!this._settingsLoaded}">
-						<d2l-input-checkbox
-							id="showCourseCodeCheckbox"
-							?checked=${this._savedShowCourseCode}
-							@change=${this._onShowCourseCodeChange}>${this.localize('showCourseCode')}</d2l-input-checkbox>
-						<d2l-input-checkbox
-							id="showSemesterCheckbox"
-							?checked=${this._savedShowSemester}
-							@change=${this._onShowSemesterChange}>${this.localize('showSemester')}</d2l-input-checkbox>
-					</div>
+					` : html`
+						<div class="discover-customization-settings">
+							<d2l-input-checkbox
+								id="showCourseCodeCheckbox"
+								?checked=${this._savedShowCourseCode}
+								@change=${this._onShowCourseCodeChange}>${this.localize('showCourseCode')}</d2l-input-checkbox>
+							<d2l-input-checkbox
+								id="showSemesterCheckbox"
+								?checked=${this._savedShowSemester}
+								@change=${this._onShowSemesterChange}>${this.localize('showSemester')}</d2l-input-checkbox>
+						</div>
+					`}
 					${renderToggleSections}
 				</div>
 			` : html``}
@@ -84,18 +84,18 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 					${!this._settingsLoaded ? html`
 						<d2l-input-checkbox skeleton>${this.localize('showUpdatedSection')}</d2l-input-checkbox>
 						<d2l-input-checkbox skeleton>${this.localize('showNewSection')}</d2l-input-checkbox>
-					` : html``}
-					
-					<div class="discover-customization-settings" ?hidden="${!this._settingsLoaded}">
-						<d2l-input-checkbox
-							id="showUpdatedSectionCheckbox"
-							?checked=${this._savedShowUpdatedSection}
-							@change=${this._onShowUpdatedSectionChange}>${this.localize('showUpdatedSection')}</d2l-input-checkbox>
-						<d2l-input-checkbox
-							id="showNewSectionCheckbox"
-							?checked=${this._savedShowNewSection}
-							@change=${this._onShowNewSectionChange}>${this.localize('showNewSection')}</d2l-input-checkbox>
-					</div>
+					` : html`
+						<div class="discover-customization-settings">
+							<d2l-input-checkbox
+								id="showUpdatedSectionCheckbox"
+								?checked=${this._savedShowUpdatedSection}
+								@change=${this._onShowUpdatedSectionChange}>${this.localize('showUpdatedSection')}</d2l-input-checkbox>
+							<d2l-input-checkbox
+								id="showNewSectionCheckbox"
+								?checked=${this._savedShowNewSection}
+								@change=${this._onShowNewSectionChange}>${this.localize('showNewSection')}</d2l-input-checkbox>
+						</div>
+					`}
 			` : html``}
 		`;
 	}

--- a/src/mixins/route-locations-mixin.js
+++ b/src/mixins/route-locations-mixin.js
@@ -33,7 +33,8 @@ const internalRouteLocationsMixin = (superClass) =>
 				myList: () => this.search('', {
 					'onMyList': true
 				}),
-				notFound: () => `${discoveryBasePath}/404`
+				notFound: () => `${discoveryBasePath}/404`,
+				noQuerySearch: () => `${discoveryBasePath}/search/`
 			};
 		}
 


### PR DESCRIPTION
[Rally User Story US120287](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F429310973704)

This PR consists of two fixes:
- It fixes all the broken navigation cause by the de-FRA, allowing the user to navigate between the different pages on Discover
- It replaces many of the events used to navigate with ones built into receptive components.

Testing Notes:
- You are able to navigate to and from the `home`, `settings` and `search` pages.
- You will not be able to navigate to the `course summary` page until the BFF routing fix is approved or from the same page until it's respective data loading fix.