### PR TITLE
Clabatt/us122033 loading skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery",
-  "version": "2.1.31",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "discovery",
   "appId": "urn:d2l:fra:class:discovery",
   "description": "Discovery",
-  "version": "2.1.31",
+  "version": "2.2.0",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "repository": "git@github.com:Brightspace/discovery-fra.git",

--- a/src/components/course-summary.js
+++ b/src/components/course-summary.js
@@ -659,6 +659,7 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 								this._enrollmentDialogMessage = this.localize('enrollmentMessageSuccess', 'title', this.courseTitle);
 							}
 							this.organizationHomepage = organizationHomepage;
+							this.selfEnrolledDate = Date.now();
 						});
 				})
 				.catch(() => {

--- a/src/components/discover-settings-promoted-content.js
+++ b/src/components/discover-settings-promoted-content.js
@@ -19,8 +19,10 @@ import { entityFactory, dispose } from 'siren-sdk/src/es6/EntityFactory';
 import { OrganizationCollectionEntity } from 'siren-sdk/src/organizations/OrganizationCollectionEntity';
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { DiscoverSettingsMixin } from '../mixins/discover-settings-mixin.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import './loading-skeleton.js';
 
-class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocationsMixin(FetchMixin(LocalizeMixin(LitElement)))) {
+class DiscoverSettingsPromotedContent extends SkeletonMixin(DiscoverSettingsMixin(RouteLocationsMixin(FetchMixin(LocalizeMixin(LitElement))))) {
 
 	static async getLocalizeResources(langs) {
 		return getLocalizeResources(langs);
@@ -50,21 +52,15 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 		return {
 			token: { type: String},
 			maxPromotedCourses: {type: Number }, //Limits the number of selectable items in the dialog's list to this number.
-
 			_promotedDialogOpen: { type: Boolean}, //True iff the dialog is open
-
 			_promotedItemsLoading: { type: Boolean}, //True until the saved promoted items are loaded.
 			_candidateItemsLoading: { type: Boolean}, //True iff any candidate image or text has not fully loaded.
 			_candidateEntityCollection: { type: Object}, //OrganizationEntityCollection siren object.
-
 			_candidateActivities: { type: Array}, //Array of objects containing properties of OrganizationEntities within the currently loaded candidates
 			_promotedActivities: { type: Array}, //Array of objects containing properties of the currently promoted activities
-
 			_loadedCandidateImages: { type: Number}, //Count of total candidate images ready to be displayed
 			_loadedCandidateText: { type: Number}, //Count of total candidate text ready to be displayed
-
 			_currentSelection: { type: Object}, //Hash of checked/unchecked organizationURLs. All true items are selected.
-
 			_selectionCount: { type: Number}, //Count of currently checked candidate entities
 			_lastLoadedListItem: {type: Object}, //Tracks the last loaded activity, to focus its new sibling after loading more.
 			_savedPromotedActivities: { type: Array}, //initial load of promoted courses
@@ -129,27 +125,16 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 				margin-top: .5rem;
 				margin-bottom: .5rem;
 			}
-			.d2l-discover-list-item-pulse-placeholder {
-				animation: pulsingAnimation 1.8s linear infinite;
-				height: 100%;
-				width: 100%;
-				border-radius: 4px;
+			.img-skeleton {
+				width: 180px;
+				height: 76.66px;
 			}
-			.d2l-discover-list-item-content-placeholder {
-				flex-grow: 1;
-				display: flex;
-				flex-direction: column;
-				width: 100%;
+			.discovery-featured-placeholder-container {
+				width: 100%
 			}
-			.d2l-discover-list-item-image-placeholder {
-				width: 90px;
-				height: 38.33px;
-				border: 1px solid var(--d2l-color-gypsum);
-			}
-			.d2l-discover-list-item-category-placeholder {
-				display: block;
-				height: 0.95rem;
-				margin: 0.3rem 0;
+			.discovery-featured-title-placeholder {
+				height: 1.1rem;
+				margin: 0.17rem 0rem;
 				width: 50%;
 			}
 		`];
@@ -206,20 +191,22 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 	}
 
 	_renderFeaturedSection() {
-		const loadingPlaceholder = this._renderLoadingPlaceholder();
 		return html`
 			${this._promotedActivities.length > 0 ? html`
 				<d2l-list class="discover-featured-list">
 					${this._promotedActivities.map((activity) => html`
-						${!activity.loaded ? html`
-							${loadingPlaceholder}
-						` : html``}
-						<d2l-list-item ?hidden="${!activity.loaded}">
-							<d2l-organization-image href="${activity.organizationUrl}" slot="illustration" token="${this.token}"></d2l-organization-image>
-							<d2l-organization-name href="${activity.organizationUrl}" token="${this.token}" @d2l-organization-accessible="${(e) => this._handleSavedOrgAccessible(e, activity)}"></d2l-organization-name>
-							<div slot="actions">
-							<d2l-button-icon text="${this.localize('removeFromFeatured', 'course', activity.organizationName)}" icon="tier1:close-default" @click="${(() => this._removeFromFeatured(activity.organizationUrl))}"></d2l-button-icon>
-							</div>
+						<d2l-list-item>
+							<d2l-organization-image href="${activity.organizationUrl}" slot="illustration" token="${this.token}" class="img-skeleton" ?skeleton="${!activity.loaded}"></d2l-organization-image>
+							<d2l-organization-name href="${activity.organizationUrl}" token="${this.token}" ?hidden="${!activity.loaded}" @d2l-organization-accessible="${(e) => this._handleSavedOrgAccessible(e, activity)}"></d2l-organization-name>
+							${activity.loaded ? html`
+								<div slot="actions">
+									<d2l-button-icon text="${this.localize('removeFromFeatured', 'course', activity.organizationName)}" icon="tier1:close-default" @click="${(() => this._removeFromFeatured(activity.organizationUrl))}"></d2l-button-icon>
+								</div>
+							` : html`
+								<div class="discovery-featured-placeholder-container">
+									<loading-skeleton class="discovery-featured-title-placeholder"></loading-skeleton>
+								</div>
+							`}
 						</d2l-list-item>
 					`)}
 				</d2l-list>
@@ -236,12 +223,10 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 			${this._candidateEntityCollection === undefined || this._candidateEntityCollection === null ? null : html`
 				${this._candidateActivities.length <= 0 && !this._candidateItemsLoading && !this._promotedItemsLoading ? html`
 					<div class="discover-featured-empty">${this.localize('noActivitiesFound')}</div>` : html`
-
 					<d2l-list @d2l-list-selection-change=${this._handleSelectionChange}>
 					${this._candidateActivities.map(activity => html`
 						<d2l-list-item selectable ?hidden="${!activity.loaded}" key="${activity.organizationUrl}"
 							?selected="${this._isCandidateSelected(activity)}" ?disabled="${this._isCandidateDisabled(activity)}">
-
 							<d2l-organization-image href="${activity.organizationUrl}" slot="illustration" token="${this.token}" @d2l-organization-image-loaded="${this._handleOrgImageLoaded}"></d2l-organization-image>
 							<d2l-organization-name href="${activity.organizationUrl}" token="${this.token}" @d2l-organization-accessible="${this._handleCandidateOrgAccessible}"></d2l-organization-name>
 						</d2l-list-item>
@@ -274,19 +259,6 @@ class DiscoverSettingsPromotedContent extends DiscoverSettingsMixin(RouteLocatio
 					<d2l-button @click=${this._loadMoreCandidates}>${this.localize('loadMore')}</d2l-button>
 				`}
 			`}
-		`;
-	}
-
-	_renderLoadingPlaceholder() {
-		return html`
-			<d2l-list-item>
-				<div slot="illustration" class="d2l-discover-list-item-image-placeholder">
-					<div class="d2l-discover-list-item-pulse-placeholder"></div>
-				</div>
-				<div class="d2l-discover-list-item-content-placeholder">
-					<div class="d2l-discover-list-item-pulse-placeholder d2l-discover-list-item-category-placeholder"></div>
-				</div>
-			</d2l-list-item>
 		`;
 	}
 

--- a/src/discovery-settings.js
+++ b/src/discovery-settings.js
@@ -58,18 +58,18 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 					${!this._settingsLoaded ? html`
 						<d2l-input-checkbox skeleton>${this.localize('showCourseCode')}</d2l-input-checkbox>
 						<d2l-input-checkbox skeleton>${this.localize('showSemester')}</d2l-input-checkbox>
-					` : html``}
-
-					<div class="discover-customization-settings" ?hidden="${!this._settingsLoaded}">
-						<d2l-input-checkbox
-							id="showCourseCodeCheckbox"
-							?checked=${this._savedShowCourseCode}
-							@change=${this._onShowCourseCodeChange}>${this.localize('showCourseCode')}</d2l-input-checkbox>
-						<d2l-input-checkbox
-							id="showSemesterCheckbox"
-							?checked=${this._savedShowSemester}
-							@change=${this._onShowSemesterChange}>${this.localize('showSemester')}</d2l-input-checkbox>
-					</div>
+					` : html`
+						<div class="discover-customization-settings" ?hidden="${!this._settingsLoaded}">
+							<d2l-input-checkbox
+								id="showCourseCodeCheckbox"
+								?checked=${this._savedShowCourseCode}
+								@change=${this._onShowCourseCodeChange}>${this.localize('showCourseCode')}</d2l-input-checkbox>
+							<d2l-input-checkbox
+								id="showSemesterCheckbox"
+								?checked=${this._savedShowSemester}
+								@change=${this._onShowSemesterChange}>${this.localize('showSemester')}</d2l-input-checkbox>
+						</div>
+					`}
 					${renderToggleSections}
 				</div>
 			` : html``}
@@ -84,18 +84,18 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 					${!this._settingsLoaded ? html`
 						<d2l-input-checkbox skeleton>${this.localize('showUpdatedSection')}</d2l-input-checkbox>
 						<d2l-input-checkbox skeleton>${this.localize('showNewSection')}</d2l-input-checkbox>
-					` : html``}
-					
-					<div class="discover-customization-settings" ?hidden="${!this._settingsLoaded}">
-						<d2l-input-checkbox
-							id="showUpdatedSectionCheckbox"
-							?checked=${this._savedShowUpdatedSection}
-							@change=${this._onShowUpdatedSectionChange}>${this.localize('showUpdatedSection')}</d2l-input-checkbox>
-						<d2l-input-checkbox
-							id="showNewSectionCheckbox"
-							?checked=${this._savedShowNewSection}
-							@change=${this._onShowNewSectionChange}>${this.localize('showNewSection')}</d2l-input-checkbox>
-					</div>
+					` : html`
+						<div class="discover-customization-settings" ?hidden="${!this._settingsLoaded}">
+							<d2l-input-checkbox
+								id="showUpdatedSectionCheckbox"
+								?checked=${this._savedShowUpdatedSection}
+								@change=${this._onShowUpdatedSectionChange}>${this.localize('showUpdatedSection')}</d2l-input-checkbox>
+							<d2l-input-checkbox
+								id="showNewSectionCheckbox"
+								?checked=${this._savedShowNewSection}
+								@change=${this._onShowNewSectionChange}>${this.localize('showNewSection')}</d2l-input-checkbox>
+						</div>
+					`}
 			` : html``}
 		`;
 	}

--- a/src/lang/ar.js
+++ b/src/lang/ar.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "تم تحديد {count} ∕ {maximum}.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "قسم مميّز", // The header for setting the featured items in Discover.
 	showCourseCode: "عرض رموز المقرر التعليمي", // The setting for whether or not to display course codes within Discover.
-	showSemester: "عرض الفصول الدراسية" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "عرض الفصول الدراسية", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "إظهار القسم المحدّث", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "إظهار القسم الجديد", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "الإطارات المتجانبة للمقرر التعليمي", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "المقاطع" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/cy-gb.js
+++ b/src/lang/cy-gb.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} / {maximum} wedi’u dewis.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Adran Dan Sylw", // The header for setting the featured items in Discover.
 	showCourseCode: "Dangos codau cwrs", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Dangos semestrau" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Dangos semestrau", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Dangos yr adran Diweddarwyd", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Dangos yr adran Newydd", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Teils y Cwrs", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Adrannau" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/da-dk.js
+++ b/src/lang/da-dk.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} ∕ {maximum} valgt.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Fremhævet sektion", // The header for setting the featured items in Discover.
 	showCourseCode: "Vis kursuskoder", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Vis semestre" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Vis semestre", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Vis opdateret sektion", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Vis ny sektion", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Kursusfelter", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Sektioner" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count}∕{maximum} ausgewählt.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Abschnitt „Angeboten“", // The header for setting the featured items in Discover.
 	showCourseCode: "Kurscodes anzeigen", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Semester anzeigen" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Semester anzeigen", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Aktualisierten Abschnitt anzeigen", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Neuen Abschnitt anzeigen", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Kurs-Kacheln", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Abschnitte" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/es-es.js
+++ b/src/lang/es-es.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} ∕ {maximum} seleccionado(s).", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Sección destacada", // The header for setting the featured items in Discover.
 	showCourseCode: "Mostrar códigos del curso", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Mostrar semestres" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Mostrar semestres", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Mostrar Sección actualizada", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Mostrar Nueva sección", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Mosaicos del curso", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Secciones" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count}∕{maximum} seleccionados.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Sección destacada", // The header for setting the featured items in Discover.
 	showCourseCode: "Mostrar códigos del curso", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Mostrar semestres" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Mostrar semestres", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Mostrar sección actualizada", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Mostrar sección nueva", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Mosaicos de cursos", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Secciones" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/fr-fr.js
+++ b/src/lang/fr-fr.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} ∕ {maximum} sélectionnés.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Section à la une", // The header for setting the featured items in Discover.
 	showCourseCode: "Afficher les codes de cours", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Afficher les semestres" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Afficher les semestres", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Afficher la section mise à jour", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Afficher la nouvelle section", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Mosaïques de cours", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Sections" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} ∕ {maximum} sélectionné(s).", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Section des propositions", // The header for setting the featured items in Discover.
 	showCourseCode: "Afficher les codes de cours", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Afficher les semestres" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Afficher les semestres", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Montrer la section mise à jour", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Montrer la nouvelle section", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Tuiles de cours", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Sections" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count}/{maximum} 件を選択済み。", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "注目のセクション", // The header for setting the featured items in Discover.
 	showCourseCode: "コースコードの表示", // The setting for whether or not to display course codes within Discover.
-	showSemester: "学期の表示" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "学期の表示", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "更新されたセクションの表示", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "新規セクションの表示", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "コースタイル", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "セクション" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/ko.js
+++ b/src/lang/ko.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} ∕ {maximum}개의 항목이 선택되었습니다.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "추천 섹션", // The header for setting the featured items in Discover.
 	showCourseCode: "Show course codes", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Show semesters" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Show semesters", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "업데이트된 섹션 표시", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "새 섹션 표시", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "강의 타일", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "섹션" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count}/{maximum} geselecteerd.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Uitgelichte sectie", // The header for setting the featured items in Discover.
 	showCourseCode: "Show course codes", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Show semesters" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Show semesters", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Bijgewerkte sectie weergeven", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Nieuwe sectie weergeven", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Cursustegels", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Secties" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} ∕ {maximum} selecionado.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Seção em destaque", // The header for setting the featured items in Discover.
 	showCourseCode: "Mostrar códigos de curso", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Mostrar semestres" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Mostrar semestres", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Mostrar seção atualizada", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Mostrar nova seção", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Blocos de curso", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Seções" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/sv.js
+++ b/src/lang/sv.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count}∕{maximum} har valts.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Valt avsnitt", // The header for setting the featured items in Discover.
 	showCourseCode: "Visa kurskoder", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Visa terminer" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Visa terminer", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Visa avsnittet Uppdaterat", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Visa avsnittet Nytt", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Kurspaneler", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Sektioner" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/tr.js
+++ b/src/lang/tr.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "{count} ∕ {maximum} öğe seçildi.", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "Öne Çıkarılan Bölüm", // The header for setting the featured items in Discover.
 	showCourseCode: "Ders kodlarını göster", // The setting for whether or not to display course codes within Discover.
-	showSemester: "Dönemleri göster" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "Dönemleri göster", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "Güncellenen bölümü göster", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "Yeni bölümü göster", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "Ders Kutucukları", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "Bölümler" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/zh-tw.js
+++ b/src/lang/zh-tw.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "已選取 {count} 個，上限為 {maximum} 個。", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "特色章節", // The header for setting the featured items in Discover.
 	showCourseCode: "顯示課程代碼", // The setting for whether or not to display course codes within Discover.
-	showSemester: "顯示學期" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "顯示學期", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "顯示已更新章節", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "顯示新章節", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "課程標題", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "章節" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang/zh.js
+++ b/src/lang/zh.js
@@ -26,5 +26,9 @@ export default {
 	selectedFromMaximum: "已选 {count} 个（共 {maximum} 个）。", // The number of currently selected featured activities out of a maximum available.
 	settingsFeaturedSection: "特色部分", // The header for setting the featured items in Discover.
 	showCourseCode: "显示课程代码", // The setting for whether or not to display course codes within Discover.
-	showSemester: "显示学期" // The setting for whether or not to display semecter names within Discover.
+	showSemester: "显示学期", // The setting for whether or not to display semecter names within Discover.
+	showUpdatedSection: "显示更新的章节", // The setting for whether or not to display the Updated section on the Discover homepage.
+	showNewSection: "显示新章节", // The setting for whether or not to display the New section on the Discover homepage.
+	courseTileSettings: "课程图块", // The subheader for the settings that determine what to display within course tiles.
+	sectionsSettings: "章节" // The subheader for the settings that determine which sections will be shown on the Discover homepage.
 };

--- a/src/lang_polymer/ar.js
+++ b/src/lang_polymer/ar.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "عُد إلى الصفحة الرئيسية.", // An action that will navigate the user back to the Discover homepage.
 	new: "الجديدة", // The name of the homepage section for new activities.
 	noActivities: "لا تتوفر أي أنشطة، أو سبق أن تم تسجيلك في الأنشطة كلها. حاول مرة أخرى في وقت لاحق.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "لا تتوفر أي أنشطة جديدة أو محدّثة، أو سبق أن تم تسجيلك في الأنشطة كلها. حاول مرة أخرى في وقت لاحق.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "لا تتوفر أي أنشطة إضافية، أو سبق أن تم تسجيلك في الأنشطة كلها. حاول مرة أخرى في وقت لاحق.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "لا تتوفر مقررات تعليمية تمت إضافتها حديثًا.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "لست مسجّلاً حاليًا في أي مقرر تعليمي.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "يُرجى استخدام طريقة فرز مختلفة.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "لا تتوفر أي نتائج للأكثر صلة.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "لا تتوفر مقررات تعليمية تم تحديثها مؤخرًا.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "ما من وصف للمقرر التعليمي", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "ما من نتائج لـ \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "حاول استخدام مصطلح بحث مختلف أو {linkStart}استعراض الكل{linkEnd} لعرض كل المواد المتوفرة", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/cy-gb.js
+++ b/src/lang_polymer/cy-gb.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Mynd yn ôl i’r dudalen hafan.", // An action that will navigate the user back to the Discover homepage.
 	new: "Newydd", // The name of the homepage section for new activities.
 	noActivities: "Nid oes unrhyw weithgareddau ar gael neu rydych chi eisoes wedi cofrestru ar gyfer pob un ohonynt. Rhowch gynnig arall arni’n hwyrach.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Nid oes unrhyw weithgareddau newydd neu wedi’u diweddaru ar gael neu rydych chi eisoes wedi cofrestru ar gyfer pob un ohonynt. Rhowch gynnig arall arni’n hwyrach.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Nid oes unrhyw weithgareddau ychwanegol ar gael neu rydych chi eisoes wedi cofrestru ar gyfer pob un ohonynt. Rhowch gynnig arall arni’n hwyrach.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Nid oes unrhyw gyrsiau sydd newydd eu hychwanegu.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Ar hyn o bryd nid ydych wedi cofrestru mewn unrhyw gyrsiau.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Defnyddiwch ddull trefnu gwahanol.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Dim canlyniadau ar gyfer Mwyaf Perthnasol.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Nid oes unrhyw gyrsiau newydd eu diweddaru.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Dim disgrifiad o’r cwrs", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Dim canlyniadau ar gyfer \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "Ceisiwch ddefnyddio term chwilio gwahanol neu {linkStart}Pori’r Cyfan{linkEnd} i weld yr holl ddeunyddiau sydd ar gael", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/da-dk.js
+++ b/src/lang_polymer/da-dk.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Gå tilbage til startsiden.", // An action that will navigate the user back to the Discover homepage.
 	new: "Ny", // The name of the homepage section for new activities.
 	noActivities: "Der er ingen aktiviteter tilgængelige, eller du er allerede tilmeldt dem alle. Prøv igen senere.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Der er ingen nye eller opdaterede aktiviteter tilgængelige, eller du er allerede tilmeldt dem alle. Prøv igen senere.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Der er ikke flere tilgængelige aktiviteter, eller du er allerede tilmeldt dem alle. Prøv igen senere.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Der er ingen kurser tilføjet for nylig.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Du er ikke tilmeldt nogen kurser i øjeblikket.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Brug en anden sorteringsmetode.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Ingen resultater for Mest relevant.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Der er ingen kurser, der er blevet opdateret for nylig.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Ingen kursusbeskrivelse", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Ingen resultater for \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "Prøv at bruge et andet søgeord eller {linkStart}Gennemse alle{linkEnd} for at få vist alt tilgængeligt materiale", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/de.js
+++ b/src/lang_polymer/de.js
@@ -38,11 +38,16 @@ export default {
 	homepageDocumentTitle: "Discover – {instanceName}", // Displays as the page/tab header for the homepage.
 	lastUpdatedDate: "Zuletzt aktualisiert am {date}", //The most recent date that the current course was updated
 	loadMore: "Mehr laden", // An action that will load additional activities to be displayed.
-	message404: "Hoppla, Sie sind auf einen Fehler 404 gestoßen.", // A 404 message that appears when the user navigates to a page that doesn't exist.
+	message404: "Hoppla, Sie sind auf einen Fehler 404 gestoßen.", // A 404 message that appears when the user navigates to a page that doesn't exist.
 	navigateHome: "Zurück zur Startseite.", // An action that will navigate the user back to the Discover homepage.
 	new: "Neu", // The name of the homepage section for new activities.
 	noActivities: "Es sind keine Aktivitäten verfügbar, oder Sie sind bereits bei allen Aktivitäten angemeldet. Versuchen Sie es später noch einmal.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Es sind keine neuen oder aktualisierten Aktivitäten verfügbar, oder Sie sind bereits bei allen Aktivitäten angemeldet. Versuchen Sie es später noch einmal.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Es sind keine zusätzlichen Aktivitäten verfügbar, oder Sie sind bereits bei allen Aktivitäten angemeldet. Versuchen Sie es später noch einmal.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Es gibt keine neu hinzugefügten Kurse.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Sie sind derzeit für keine Kurse angemeldet.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Verwenden Sie eine andere Sortiermethode.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Keine Ergebnisse für „Am relevantesten“.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Es gibt keine neu aktualisierten Kurse.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Keine Kursbeschreibung", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Keine Ergebnisse für „{searchQuery}“", // Displays as a header when a search query has no results
 	noResultsMessage: "Versuchen Sie, einen anderen Suchbegriff zu verwenden, oder {linkStart}durchstöbern Sie alles{linkEnd}, um sich alle verfügbaren Materialien anzeigen zu lassen.", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/en.js
+++ b/src/lang_polymer/en.js
@@ -42,7 +42,7 @@ export default {
 	navigateHome: "Head back to home.", // An action that will navigate the user back to the Discover homepage.
 	new: "New", // The name of the homepage section for new activities.
 	noActivities: "There are no activities available or you're already enrolled in all of them. Try again later.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "There are no new or updated activities available or you're already enrolled in all of them. Try again later.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "There are no additional activities available or you're already enrolled in all of them. Try again later.", // When only promoted activities are displayed on the homepage, this will display underneath.
 	noContentAdded: "There are no newly-added courses.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
 	noContentEnrolled: "You are not currently enrolled in any courses.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
 	noContentMessage: "Please use a different sorting method.", // Displays in a search result when no content is loaded and nothing was searched.

--- a/src/lang_polymer/es-es.js
+++ b/src/lang_polymer/es-es.js
@@ -38,11 +38,16 @@ export default {
 	homepageDocumentTitle: "Descubrir: {instanceName}", // Displays as the page/tab header for the homepage.
 	lastUpdatedDate: "Última actualización {date}", //The most recent date that the current course was updated
 	loadMore: "Cargar más", // An action that will load additional activities to be displayed.
-	message404: "Lo sentimos. Se ha producido un 404.", // A 404 message that appears when the user navigates to a page that doesn't exist.
+	message404: "Lo sentimos. Se ha producido un error 404.", // A 404 message that appears when the user navigates to a page that doesn't exist.
 	navigateHome: "Regresar a la página de inicio.", // An action that will navigate the user back to the Discover homepage.
 	new: "Nuevas", // The name of the homepage section for new activities.
 	noActivities: "No hay ninguna actividad disponible o ya se ha inscrito en todas. Vuelva a intentarlo más tarde.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "No hay ninguna actividad nueva o actualizada disponible o ya se ha inscrito en todas. Vuelva a intentarlo más tarde.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "No hay ninguna actividad adicional disponible o ya se ha inscrito en todas. Vuelva a intentarlo más tarde.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "No hay cursos recién añadidos.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "En este momento, no está inscrito en ningún curso.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Utilice un método de clasificación diferente.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "No hay resultados para Más relevante.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "No hay cursos actualizados recientemente.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Sin descripción del curso", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "No hay resultados para \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "Intente utilizar un término de búsqueda distinto o {linkStart}Examinar todo{linkEnd} para ver todos los materiales disponibles.", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/es.js
+++ b/src/lang_polymer/es.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Regresar a la página de inicio.", // An action that will navigate the user back to the Discover homepage.
 	new: "Nuevo", // The name of the homepage section for new activities.
 	noActivities: "No hay actividades disponibles o ya está inscrito en todas ellas. Inténtelo de nuevo más tarde.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "No hay actividades nuevas ni actualizadas disponibles o ya está inscrito en todas ellas. Inténtelo de nuevo más tarde.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "No hay actividades adicionales disponibles o ya está inscrito en todas ellas. Inténtelo de nuevo más tarde.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "No hay cursos recientemente agregados.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "En este momento, no está inscrito en ningún curso.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Utilice un método de clasificación diferente.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "No hay resultados para la opción “Más relevante”.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "No hay cursos recientemente actualizados.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Sin descripción del curso", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "No hay resultados para \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "Intente utilizar un término de búsqueda distinto o use {linkStart}Examinar todo{linkEnd} para ver todos los materiales disponibles", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/fr-fr.js
+++ b/src/lang_polymer/fr-fr.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Revenir à la page d’accueil.", // An action that will navigate the user back to the Discover homepage.
 	new: "Nouveau", // The name of the homepage section for new activities.
 	noActivities: "Aucune activité disponible ou vous êtes déjà inscrit à toutes les activités. Réessayez ultérieurement.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Il n’y a pas d’activité nouvelle ou mise à jour ou vous êtes déjà inscrit à toutes les activités. Réessayez ultérieurement.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Aucune activité supplémentaire disponible ou vous êtes déjà inscrit à toutes les activités. Réessayez ultérieurement.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Il n’y a pas de cours récemment ajoutés.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Vous n’êtes actuellement inscrit à aucun cours.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Veuillez utiliser une autre méthode de tri.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Aucun résultat pour le filtre « Plus pertinent ».", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Il n’y a pas de cours récemment mis à jour.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Aucune description de cours", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Aucun résultat pour « {searchQuery} »", // Displays as a header when a search query has no results
 	noResultsMessage: "Essayez d’utiliser un autre terme de recherche ou {linkStart}Tout parcourir{linkEnd} pour afficher tout le matériel disponible", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/fr.js
+++ b/src/lang_polymer/fr.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Revenir à la page d’accueil.", // An action that will navigate the user back to the Discover homepage.
 	new: "Nouveau", // The name of the homepage section for new activities.
 	noActivities: "Aucune activité disponible ou vous êtes déjà inscrit(e) dans chacune d’elles. Réessayez plus tard.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Aucune activité nouvelle ou mise à jour n’est disponible, ou vous êtes déjà inscrit(e) à toutes les activités. Réessayez plus tard.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Aucune activité supplémentaire disponible ou vous êtes déjà inscrit(e) dans chacune d\'elles. Réessayez plus tard.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Aucun cours nouvellement ajouté.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Vous n\'êtes inscrit à aucun cours actuellement", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Veuillez utiliser une autre méthode de tri.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Aucun résultat pour Plus pertinent.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Aucun cours nouvellement mis à jour.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Aucune description du cours", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Aucun résultat pour « {searchQuery} »", // Displays as a header when a search query has no results
 	noResultsMessage: "Essayer un terme de recherche différent ou {linkStart}parcourez tout{linkEnd} pour voir tout le matériel disponible", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/ja.js
+++ b/src/lang_polymer/ja.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "ホームに戻ります。", // An action that will navigate the user back to the Discover homepage.
 	new: "新規", // The name of the homepage section for new activities.
 	noActivities: "使用可能なアクティビティがないか、すべてのアクティビティにすでに登録済みです。後でもう一度試してください。", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "使用可能な新規または更新済みのアクティビティがないか、すべてのアクティビティにすでに登録済みです。後でもう一度試してください。", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "使用可能な追加のアクティビティがないか、すべてのアクティビティにすでに登録済みです。後でもう一度試してください。", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "新規追加のコースはありません。", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "現在どのコースにも登録されていません。", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "別の並べ替え方式を使用してください。", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "関連性が最も高い検索結果はありません。", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "新規更新のコースはありません。", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "コースの説明がありません", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "「{searchQuery}」の検索結果はありません", // Displays as a header when a search query has no results
 	noResultsMessage: "別の語句で検索するか、{linkStart}すべてを参照{linkEnd}して使用可能なすべての資料を表示してください", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/ko.js
+++ b/src/lang_polymer/ko.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "홈으로 돌아갑니다.", // An action that will navigate the user back to the Discover homepage.
 	new: "신규", // The name of the homepage section for new activities.
 	noActivities: "사용 가능한 활동이 없거나 이미 모든 활동에 등록되어 있습니다. 나중에 다시 시도하십시오.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "새로운 또는 업데이트된 활동이 없거나 이미 모든 활동에 등록되어 있습니다. 나중에 다시 시도하십시오.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "사용 가능한 추가 활동이 없거나 이미 모든 활동에 등록되어 있습니다. 나중에 다시 시도하십시오.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "새로 추가된 강의가 없습니다.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "현재 어느 강의에도 등록되어 있지 않습니다.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "다른 점수 산정법을 사용하십시오.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "가장 관련성이 높은 결과는 없습니다.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "새로 업데이트된 강의가 없습니다.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "강의 설명 없음", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "\"{searchQuery}\"에 대한 결과 없음", // Displays as a header when a search query has no results
 	noResultsMessage: "사용 가능한 모든 자료를 살펴보려면 다른 검색어 또는 {linkStart}모두 찾아보기{linkEnd}를 사용해 보십시오.", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/nl.js
+++ b/src/lang_polymer/nl.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Terug naar de startpagina.", // An action that will navigate the user back to the Discover homepage.
 	new: "Nieuw", // The name of the homepage section for new activities.
 	noActivities: "Er zijn geen activiteiten beschikbaar of u hebt u al voor alle activiteiten ingeschreven. Probeer het later opnieuw.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Er zijn geen nieuwe of bijgewerkte activiteiten beschikbaar of u hebt u al voor alle activiteiten ingeschreven. Probeer het later opnieuw.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Er zijn geen aanvullende activiteiten beschikbaar of u hebt u al voor alle activiteiten ingeschreven. Probeer het later opnieuw.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Er zijn geen onlangs toegevoegde cursussen.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "U bent momenteel niet ingeschreven voor cursussen.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Gebruik een andere sorteermethode.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Geen resultaten voor Meest relevant.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Er zijn geen onlangs bijgewerkte cursussen.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Geen cursusbeschrijving", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Geen resultaten voor \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "Probeer een andere zoekterm of {linkStart}Blader door alle inhoud{linkEnd} om alle beschikbare materialen te bekijken", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/pt.js
+++ b/src/lang_polymer/pt.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Volte ao início.", // An action that will navigate the user back to the Discover homepage.
 	new: "Nova", // The name of the homepage section for new activities.
 	noActivities: "Não há atividades disponíveis ou você já se inscreveu em todas elas. Tente novamente mais tarde.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Não há atividades novas ou atualizadas disponíveis ou você já se inscreveu em todas elas. Tente novamente mais tarde.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Não há atividades adicionais disponíveis ou você já se inscreveu em todas elas. Tente novamente mais tarde.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Não há cursos adicionados recentemente.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Você não está inscrito em nenhum curso no momento.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Use um método de classificação diferente.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Nenhum resultado para o mais relevante.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Não há cursos atualizados recentemente.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Não há descrição do curso", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Nenhum resultado para \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "Use um termo de pesquisa diferente ou clique em {linkStart}Procurar todos{linkEnd} para visualizar todos os materiais disponíveis", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/sv.js
+++ b/src/lang_polymer/sv.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Tillbaka till startsidan.", // An action that will navigate the user back to the Discover homepage.
 	new: "Ny", // The name of the homepage section for new activities.
 	noActivities: "Det finns inga tillgängliga aktiviteter eller så är du redan registrerad i alla. Försök igen senare.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Det finns inga nya eller uppdaterade aktiviteter tillgängliga eller så är du redan registrerad i alla. Försök igen senare.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Det finns inga ytterligare tillgängliga aktiviteter, alternativt så är du redan registrerad för alla. Försök igen senare.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Det finns inga nyligen tillagda kurser.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Du är inte registrerad för några kurser.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Använd en annan sorteringsmetod.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "Det gick inte att hitta något resultat för Mest relevanta.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Det finns inga nyligen uppdaterade kurser.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Ingen kursbeskrivning", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "Inga resultat för \"{searchQuery}\"", // Displays as a header when a search query has no results
 	noResultsMessage: "Prova med ett annat sökord eller {linkStart}Bläddra bland alla{linkEnd} för att visa alla tillgängliga material", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/tr.js
+++ b/src/lang_polymer/tr.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "Ana sayfaya geri dönün.", // An action that will navigate the user back to the Discover homepage.
 	new: "Yeni", // The name of the homepage section for new activities.
 	noActivities: "Mevcut etkinlik yok veya zaten tümüne kayıtlısınız. Daha sonra tekrar deneyin.", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "Mevcut yeni veya güncellenmiş etkinlik yok veya zaten tümüne kayıtlısınız. Daha sonra tekrar deneyin.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "Mevcut ek etkinlik yok veya zaten tümüne kayıtlısınız. Daha sonra tekrar deneyin.", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "Yeni eklenen ders yok.", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "Şu anda herhangi bir derse kayıtlı değilsiniz.", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "Lütfen farklı bir sıralama yöntemi kullanın.", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "En İlgili için sonuç yok.", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "Yeni güncellenen ders yok.", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "Ders açıklaması yok", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "\"{searchQuery}\" için sonuç bulunamadı", // Displays as a header when a search query has no results
 	noResultsMessage: "Farklı bir arama terimi kullanmayı deneyin veya mevcut tüm materyalleri görüntülemek için {linkStart}Tümüne Gözat{linkEnd} seçeneğini belirleyin", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/zh-tw.js
+++ b/src/lang_polymer/zh-tw.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "返回首頁。", // An action that will navigate the user back to the Discover homepage.
 	new: "新式", // The name of the homepage section for new activities.
 	noActivities: "沒有可用的活動或您已經註冊所有的活動。請稍後再試。", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "沒有全新或更新的活動可用，或您已經註冊所有的活動。請稍後再試。", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "沒有其他可用的活動，或您已經註冊所有的活動。請稍後再試。", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "沒有最近新增的課程。", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "您目前未註冊任何課程。", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "請使用不同的排序方法。", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "沒有「最相關」項目的結果。", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "沒有最近更新的課程。", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "沒有課程說明", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "沒有任何結果符合「{searchQuery}」", // Displays as a header when a search query has no results
 	noResultsMessage: "請嘗試使用不同的搜尋詞彙，或是{linkStart}瀏覽全部{linkEnd}以檢視所有可用的資料", // When a search query has no results, suggests different search term or filter.

--- a/src/lang_polymer/zh.js
+++ b/src/lang_polymer/zh.js
@@ -42,7 +42,12 @@ export default {
 	navigateHome: "返回主页。", // An action that will navigate the user back to the Discover homepage.
 	new: "新式", // The name of the homepage section for new activities.
 	noActivities: "没有可用的活动或者您已注册所有活动。请稍后重试。", // When there are no activities to display on the homepage, this message will display.
-	noActivitiesExceptPrmoted: "没有新的或更新的可用活动或者您已注册所有活动。请稍后重试。", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noActivitiesExceptPrmoted: "没有可用的活动或者您已注册所有活动。请稍后重试。", // When only promoted activities are displayed on the homepage, this will display underneath.
+	noContentAdded: "没有新添加的课程。", // Displays as a header when sorting by newly added while having no courses be new (within whatever the specified timeframe is).
+	noContentEnrolled: "您当前未注册任何课程。", // Displays as a header when sorting by enrolled while not having any courses enrolled.
+	noContentMessage: "请使用不同的排序方法。", // Displays in a search result when no content is loaded and nothing was searched.
+	noContentRelevant: "没有最相关的结果。", // Displays as a header when sorting by relevant while there being no courses to enroll in that haven't already been enrolled in.
+	noContentUpdated: "没有新更新的课程。", // Displays as a header when sorting by newly updated while having no courses be recently updated (within whatever the specified timeframe is).
 	noCourseDescription: "无课程描述", // Displays in a course's summary if it does not have a description.
 	noResultsHeading: "未找到“{searchQuery}”的结果", // Displays as a header when a search query has no results
 	noResultsMessage: "尝试使用其他搜索词或{linkStart}浏览所有{linkEnd}以查看所有可用材料", // When a search query has no results, suggests different search term or filter.


### PR DESCRIPTION
[Rally User Story US122033](https://rally1.rallydev.com/#/357252275780d/dashboard?detail=%2Fuserstory%2F450333016468)

Because of the FRA to BSI conversion, the loading skeletons for the checkboxes and the promoted courses were no longer worked the way intended. Now the loading skeletons for the settings checkboxes are the only part shown until the settings have loaded in and the animation of the skeleton for the featured course was also fixed, by implementing the [SkeletonMixin from Core.](https://github.com/BrightspaceUI/core/blob/master/components/skeleton/skeleton-mixin.js)