### PR TITLE
implement lit single page app routing mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5899,23 +5899,6 @@
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       },
       "dependencies": {
-        "@brightspace-ui/core": {
-          "version": "1.102.4",
-          "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.102.4.tgz",
-          "integrity": "sha512-wBfrjTWhQFLQXwwFyYqrVESNwzZOUY0SzmeOolkd2I3N8aS9v2U2ApxnZ43qBTmFqpO7i3Kbxkvnn/TT+aI7Cw==",
-          "requires": {
-            "@brightspace-ui/intl": "^3",
-            "@formatjs/intl-pluralrules": "^1",
-            "@open-wc/dedupe-mixin": "^1.2.17",
-            "@webcomponents/shadycss": "^1",
-            "@webcomponents/webcomponentsjs": "^2",
-            "focus-visible": "^5",
-            "intl-messageformat": "^7",
-            "lit-element": "^2",
-            "prismjs": "^1",
-            "resize-observer-polyfill": "^1"
-          }
-        },
         "del": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5899,6 +5899,23 @@
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       },
       "dependencies": {
+        "@brightspace-ui/core": {
+          "version": "1.102.4",
+          "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.102.4.tgz",
+          "integrity": "sha512-wBfrjTWhQFLQXwwFyYqrVESNwzZOUY0SzmeOolkd2I3N8aS9v2U2ApxnZ43qBTmFqpO7i3Kbxkvnn/TT+aI7Cw==",
+          "requires": {
+            "@brightspace-ui/intl": "^3",
+            "@formatjs/intl-pluralrules": "^1",
+            "@open-wc/dedupe-mixin": "^1.2.17",
+            "@webcomponents/shadycss": "^1",
+            "@webcomponents/webcomponentsjs": "^2",
+            "focus-visible": "^5",
+            "intl-messageformat": "^7",
+            "lit-element": "^2",
+            "prismjs": "^1",
+            "resize-observer-polyfill": "^1"
+          }
+        },
         "del": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
@@ -6373,6 +6390,13 @@
         "s-html": "github:Brightspace/s-html#semver:^2",
         "siren-entity": "github:BrightspaceHypermediaComponents/siren-entity#semver:^1",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
+      },
+      "dependencies": {
+        "@brightspace-ui/intl": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.1.2.tgz",
+          "integrity": "sha512-k16rbZlcKCJso8HkA/95K4Dek/tnufDj97+1XYZFW6x7StqzrQgZgvEMfnfiFsRvmy10hlYpqtGp/7SDZsTP6g=="
+        }
       }
     },
     "d2l-simple-overlay": {
@@ -9696,7 +9720,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0"
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {
@@ -11716,6 +11741,11 @@
         "lit-html": "^1.1.1"
       }
     },
+    "lit-element-router": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lit-element-router/-/lit-element-router-2.0.3.tgz",
+      "integrity": "sha512-ASaFeB5E4hsd2LYH3keY3ImuaW1+Dc3BcjauTRZhVcYmEIYDkIs/ci7Vfv/SroHhbyQ5nF/nPFBcOFipYsGwXg=="
+    },
     "lit-html": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
@@ -12523,6 +12553,13 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "discovery",
   "appId": "urn:d2l:fra:class:discovery",
   "description": "Discovery",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "repository": "git@github.com:Brightspace/discovery-fra.git",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
     "dompurify": "^2.2.2",
     "fastdom": "^1.0.8",
+    "lit-element-router": "^2.0.3",
     "promise-polyfill": "8.1.0",
     "siren-parser": "^8.2.0",
     "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",

--- a/src/components/home-header.js
+++ b/src/components/home-header.js
@@ -142,6 +142,7 @@ class HomeHeader extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 	constructor() {
 		super();
 		this.query = '';
+		this.showSettingsButton = false;
 	}
 	static get properties() {
 		return {

--- a/src/discovery-404.js
+++ b/src/discovery-404.js
@@ -1,8 +1,9 @@
 'use strict';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { LocalizeMixin } from './mixins/localize-mixin.js';
+import { RouteLocationsMixin } from './mixins/route-locations-mixin.js';
 
-class Discovery404 extends LocalizeMixin(PolymerElement) {
+class Discovery404 extends RouteLocationsMixin(LocalizeMixin(PolymerElement)) {
 	static get template() {
 		return html`
 	  		<style>
@@ -19,7 +20,7 @@ class Discovery404 extends LocalizeMixin(PolymerElement) {
 	_goToHome() {
 		this.dispatchEvent(new CustomEvent('navigate', {
 			detail: {
-				path: '/d2l/le/discovery/view/'
+				path:  this.routeLocations().navLink()
 			},
 			bubbles: true,
 			composed: true,

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -83,9 +83,9 @@ export class DiscoveryApp extends (navigator(router(FetchMixin(FeatureMixin(Rout
 			case 'settings': return html `
 				<discovery-settings
 					name="settings"
-					can-manage-discover="${this._manageDiscover}"
-					discover-customizations-enabled = "${this._discoverCustomizationsEnabled}"
-					discover-toggle-sections-enabled = "${this._discoverToggleSectionsEnabled}">
+					?can-manage-discover="${this._manageDiscover}"
+					?discover-customizations-enabled = "${this._discoverCustomizationsEnabled}"
+					?discover-toggle-sections-enabled = "${this._discoverToggleSectionsEnabled}">
 				</discovery-settings>`;
 
 			case 'course': return html `

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -130,7 +130,6 @@ export class DiscoveryApp extends (navigator(router(FetchMixin(FeatureMixin(Rout
 	_isDiscoverInitialized(resolvedToken, options) {
 		if (resolvedToken && options) {
 			return true;
-
 		}
 		return false;
 	}

--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -1,95 +1,63 @@
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { setPassiveTouchGestures, setRootPath } from '@polymer/polymer/lib/utils/settings.js';
-import '@polymer/app-route/app-route.js';
-import '@polymer/iron-pages/iron-pages.js';
-import './components/app-location-ifrau.js';
+import { LitElement, html } from 'lit-element';
 import './discovery-404.js';
 import './discovery-course.js';
 import './discovery-home.js';
 import './discovery-search.js';
 import './discovery-settings.js';
+import { navigator, router } from 'lit-element-router';
 
-import { IfrauMixin } from './mixins/ifrau-mixin.js';
 import { FeatureMixin } from './mixins/feature-mixin.js';
 import { FetchMixin } from './mixins/fetch-mixin.js';
 import { RouteLocationsMixin } from './mixins/route-locations-mixin.js';
 
-// Gesture events like tap and track generated from touch will not be
-// preventable, allowing for better scrolling performance.
-setPassiveTouchGestures(true);
-
-// Set Polymer's root path to the same value we passed to our service worker
-// in `index.html`.
-window.DiscoveryApp = window.DiscoveryApp || {};
-setRootPath(window.DiscoveryApp.rootPath);
-
-class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixin(PolymerElement)))) {
-	static get template() {
-		return html`
-			<style>
-				:host {
-					display: block;
-				}
-			</style>
-
-			<app-location-ifrau
-				route="[[route]]"
-				query-params="[[queryParams]]">
-			</app-location-ifrau>
-
-			<app-route
-				route="[[route]]"
-				pattern="/d2l/le/discovery/view/:page"
-				data="[[routeData]]"
-				tail="[[subroute]]">
-			</app-route>
-
-
-			<template is="dom-if" if="[[_isDiscoverInitialized(token, options)]]">
-				<iron-pages
-					selected="[[page]]"
-					attr-for-selected="name"
-					selected-attribute="visible"
-					role="main">
-					<discovery-home
-						name="home"
-						promoted-courses-enabled="[[_promotedCoursesEnabled]]"
-						can-manage-discover="[[_manageDiscover]]"></discovery-home>
-					<discovery-course name="course" route="[[route]]"></discovery-course>
-					<discovery-search name="search" route="[[route]]"></discovery-search>
-					<discovery-settings
-						name="settings"
-						can-manage-discover="[[_manageDiscover]]"
-						discover-customizations-enabled = "[[_discoverCustomizationsEnabled]]"
-						discover-toggle-sections-enabled = "[[_discoverToggleSectionsEnabled]]">
-					</discovery-settings>
-					<discovery-404 name="404"></discovery-404>
-				</iron-pages>
-			</template>
-		`;
+export class DiscoveryApp extends (navigator(router(FetchMixin(FeatureMixin(RouteLocationsMixin(LitElement)))))) {
+	constructor() {
+		super();
+		this.route = '';
+		this.params = {};
+		this.query = {};
+		this.data = {};
 	}
+
+	updated(changedProperties) {
+		changedProperties.forEach((oldValue, propName) => {
+			switch (propName) {
+				case 'options': this._optionsChanged();
+					break;
+				case 'token': this._tokenChanged();
+					break;
+			}
+		});
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('navigate', this._handleNavigate.bind(this));
+	}
+	disconnectedCallback() {
+		window.removeEventListener('navigate', this._handleNavigate.bind(this));
+	}
+
 	static get properties() {
 		return {
 			options: {
 				type: String,
-				observer: '_optionsChanged'
 			},
 			token: {
 				type: String,
-				observer: '_tokenChanged'
 			},
-			page: {
-				type: String,
-				reflectToAttribute: true
+			resolvedToken: {
+				type: String
 			},
-			queryParams: {
-				type: Object,
-				value: () => {
-					return {};
-				}
+			route: {
+				type: String
 			},
-			routeData: Object,
-			subroute: Object,
+			params: {
+				type: Object
+			},
+			data: {
+				type: Object
+			},
 			_promotedCoursesEnabled: {
 				type: Boolean
 			},
@@ -105,103 +73,78 @@ class DiscoveryApp extends FetchMixin(FeatureMixin(RouteLocationsMixin(IfrauMixi
 		};
 	}
 
-	constructor() {
-		super();
-		this._routeDataChangedHandled = this._routeDataChanged.bind(this);
-	}
-	ready() {
-		super.ready();
-		this.addEventListener('navigate', this._navigate);
-		this.addEventListener('navigate-parent', this._navigateParent);
+	_renderCurrentView() {
+		switch (this.route) {
+			case 'home' || '': return html `
+				<discovery-home name="home"
+					?promoted-courses-enabled="${this._promotedCoursesEnabled}"
+					?can-manage-discover="${this._manageDiscover}">
+				</discovery-home>`;
+			case 'settings': return html `
+				<discovery-settings
+					name="settings"
+					can-manage-discover="${this._manageDiscover}"
+					discover-customizations-enabled = "${this._discoverCustomizationsEnabled}"
+					discover-toggle-sections-enabled = "${this._discoverToggleSectionsEnabled}">
+				</discovery-settings>`;
 
-		const location = this.shadowRoot.querySelector('app-location-ifrau');
-		location.addEventListener('route-changed', this._routeChanged.bind(this));
-		location.addEventListener('query-params-changed', this._queryParamsChanged.bind(this));
+			case 'course': return html `
+				<discovery-course name="course" course-id="${this.params.id}"></discovery-course>`;
 
-		const route = this.shadowRoot.querySelector('app-route');
-		route.addEventListener('route-changed', this._routeChanged.bind(this));
-		route.addEventListener('tail-changed', this._subrouteChanged.bind(this));
-		route.addEventListener('data-changed', this._routeDataChanged.bind(this));
+			case 'search': return html `
+				<discovery-search name="search" query="${this.query.query}" sort="${this.query.sort}" ></discovery-search>`;
+
+			default: return html `
+				<discovery-404></discovery-404>`;
+		}
 	}
-	_navigate(e) {
+
+	render() {
+		return html`
+			${this._isDiscoverInitialized(this.resolvedToken, this.options) ? html`
+				${this._renderCurrentView(this.route)}
+			` : null }
+		`;
+	}
+
+	_handleNavigate(e) {
 		if (e && e.detail) {
 			if (e.detail.resetPages) {
 				e.detail.resetPages.forEach((page) => {
 					this._resetPage(page);
 				});
 			}
-			if (e.detail.path) {
-				this.set('route.path', e.detail.path);
-			}
+			this.navigate(e.detail.path);
 		}
-	}
-	_navigateParent(e) {
-		if (e && e.detail && e.detail.path) {
-			this._ifrauNavigationGo(e.detail.path);
-		}
-	}
-
-	_routeChanged(route) {
-		route = route.detail.value || {};
-
-		//If a user navigated via browser back/forward functionality, the path of the routes will be different.
-		if (this.route && this.route.path !== route.path) {
-			if (this.route.path === '/d2l/le/discovery/view/settings') {
-				this._resetPage('settings');
-			}
-		}
-
-		this.route = route;
-		if (route.path === '/d2l/le/discovery/view/') { // navlink home
-			var appLocationIfrau = this.shadowRoot.querySelector('app-location-ifrau');
-			if (appLocationIfrau) {
-				appLocationIfrau.rewriteTo(this.routeLocations().home());
-			}
-		}
-	}
-	_routeDataChanged(routeData) {
-		routeData = routeData.detail.value || {};
-		this.routeData = routeData;
-		const page = routeData.page || null;
-		if (page && ['home', 'course', 'search', 'settings'].indexOf(page) !== -1) {
-			this.page = page;
-		} else if (page) {
-			this.page = '404';
-		}
-	}
-	_subrouteChanged(subroute) {
-		subroute = subroute.detail.value || {};
-		this.subroute = subroute;
-	}
-	_queryParamsChanged(queryParams) {
-		queryParams = queryParams.detail.value || {};
-		this.queryParams = queryParams;
 	}
 
 	//Assigns feature/flags/endpoint/other information from LMS.
-	_optionsChanged(optionsJSON) {
-		this._initializeOptions(optionsJSON);
+	_optionsChanged() {
+		this._initializeOptions(this.options);
 		this._promotedCoursesEnabled = this._isPromotedCoursesEnabled();
 		this._manageDiscover = this._canManageDiscover();
 		this._discoverCustomizationsEnabled = this._isDiscoverCustomizationsEnabled();
 		this._discoverToggleSectionsEnabled = this._isDiscoverToggleSectionsEnabled();
 	}
 
-	_isDiscoverInitialized(token, options) {
-		if (token && options) {
+	_isDiscoverInitialized(resolvedToken, options) {
+		if (resolvedToken && options) {
 			return true;
+
 		}
 		return false;
 	}
+
 	//Retrieves a token for interacting with the BFF
-	async _tokenChanged(newValue, oldValue) {
-		if (!oldValue) {
-			this._initializeToken(newValue);
-			this._getToken(newValue).then((token) => {
-				this.token = token;
-			});
-		}
+	async _tokenChanged() {
+		this._initializeToken(this.token);
+
+		//Resolve the token
+		this._getToken().then((token) => {
+			this.resolvedToken = token;
+		});
 	}
+
 	_resetPage(pageName) {
 		const pageElement = this.shadowRoot.querySelector(`[name="${pageName}"]`);
 		if (pageElement && typeof pageElement._reset === 'function') {

--- a/src/discovery-course.js
+++ b/src/discovery-course.js
@@ -158,12 +158,6 @@ class DiscoveryCourse extends mixinBehaviors(
 				}
 			</style>
 
-			<app-route
-				route="[[route]]"
-				pattern="/d2l/le/discovery/view/course/:courseId"
-				data="[[routeData]]">
-			</app-route>
-
 			<div aria-busy$="[[!_dataIsReady]]">
 				<img id="discovery-course-header-image" on-load="_headerImageLoaded" src="[[_courseImage]]" hidden/>
 				<div class="discovery-course-header-container">
@@ -210,9 +204,10 @@ class DiscoveryCourse extends mixinBehaviors(
 
 	static get properties() {
 		return {
-			route: Object,
-			routeData: Object,
-
+			courseId:  {
+				type: Number,
+				observer: '_courseIdChanged'
+			},
 			_actionEnroll: {
 				type: String,
 				value: ''
@@ -256,30 +251,17 @@ class DiscoveryCourse extends mixinBehaviors(
 	}
 	ready() {
 		super.ready();
-		const route = this.shadowRoot.querySelector('app-route');
 		this.addEventListener('iron-resize', this._onIronResize.bind(this));
-		route.addEventListener('route-changed', this._routeChanged.bind(this));
-		route.addEventListener('data-changed', this._routeDataChanged.bind(this));
 	}
 	_visible(visible) {
 		if (visible) {
 			this._updateDocumentTitle();
 		}
 	}
-	_routeChanged(route) {
-		this.route = route.detail.value || {};
-	}
-	_routeDataChanged(routeData) {
-		this._reset();
-		this.routeData = routeData.detail.value || {};
-		// Todo: this is likely a bug in polymer where query parameters cannot be extracted from the app-route pattern
-		// We can come back to fix it in polymer later https://github.com/PolymerElements/app-route/blob/master/app-route.js#L278
-		if (this.routeData.courseId) {
-			let courseId = decodeURIComponent(this.routeData.courseId);
-			const parts = courseId.split('?');
-			if (parts.length >= 2) {
-				courseId = parts[0];
-			}
+	_courseIdChanged() {
+		if (this.courseId) {
+			const courseId = this.courseId;
+
 			const parameters = { id: courseId };
 			return this._getActionUrl('course', parameters)
 				.then(url => this._fetchEntity(url))

--- a/src/discovery-home.js
+++ b/src/discovery-home.js
@@ -48,7 +48,7 @@ class DiscoveryHome extends FeatureMixin(DiscoverSettingsMixin(FetchMixin(Locali
 
 			<div class="discovery-home-main">
 				<div class="discovery-home-home-header">
-					<home-header id="discovery-home-home-header" query="" show-settings-button="[[canManageDiscover]]"></home-header>
+					<home-header id="discovery-home-home-header" query="" show-settings-button$="[[canManageDiscover]]"></home-header>
 				</div>
 				<template is="dom-if" if="[[promotedCoursesEnabled]]">
 					<featured-list-section
@@ -95,10 +95,6 @@ class DiscoveryHome extends FeatureMixin(DiscoverSettingsMixin(FetchMixin(Locali
 
 	static get properties() {
 		return {
-			visible: {
-				type: Boolean,
-				observer: '_visible'
-			},
 			token: String,
 			promotedCoursesEnabled: Boolean,
 			canManageDiscover: Boolean,
@@ -141,6 +137,8 @@ class DiscoveryHome extends FeatureMixin(DiscoverSettingsMixin(FetchMixin(Locali
 		super.ready();
 		this.addEventListener('d2l-discover-home-all-section-courses', this._checkCoursesFromAllSection.bind(this));
 		this.addEventListener('d2l-discover-home-featured-section-courses', this._checkPromotedCourses.bind(this));
+		this._initialize();
+
 	}
 
 	_checkCoursesFromAllSection(e) {
@@ -176,10 +174,7 @@ class DiscoveryHome extends FeatureMixin(DiscoverSettingsMixin(FetchMixin(Locali
 		}
 	}
 
-	_visible(visible) {
-		if (!visible) {
-			return;
-		}
+	_initialize() {
 
 		this._updateToken();
 		this._initializeSettings();

--- a/src/discovery-home.js
+++ b/src/discovery-home.js
@@ -138,7 +138,6 @@ class DiscoveryHome extends FeatureMixin(DiscoverSettingsMixin(FetchMixin(Locali
 		this.addEventListener('d2l-discover-home-all-section-courses', this._checkCoursesFromAllSection.bind(this));
 		this.addEventListener('d2l-discover-home-featured-section-courses', this._checkPromotedCourses.bind(this));
 		this._initialize();
-
 	}
 
 	_checkCoursesFromAllSection(e) {
@@ -175,7 +174,6 @@ class DiscoveryHome extends FeatureMixin(DiscoverSettingsMixin(FetchMixin(Locali
 	}
 
 	_initialize() {
-
 		this._updateToken();
 		this._initializeSettings();
 		const instanceName = window.D2L && window.D2L.frau && window.D2L.frau.options && window.D2L.frau.options.instanceName;

--- a/src/discovery-settings.js
+++ b/src/discovery-settings.js
@@ -85,7 +85,7 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 						<d2l-input-checkbox skeleton>${this.localize('showUpdatedSection')}</d2l-input-checkbox>
 						<d2l-input-checkbox skeleton>${this.localize('showNewSection')}</d2l-input-checkbox>
 					` : html``}
-					
+
 					<div class="discover-customization-settings" ?hidden="${!this._settingsLoaded}">
 						<d2l-input-checkbox
 							id="showUpdatedSectionCheckbox"
@@ -201,14 +201,20 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 			visible: {
 				type: Boolean
 			},
+			token: {
+				type: String
+			},
 			canManageDiscover: {
-				type: Boolean
+				type: Boolean,
+				attribute: 'can-manage-discover'
 			},
 			discoverCustomizationsEnabled: {
-				type: Boolean
+				type: Boolean,
+				attribute: 'discover-customizations-enabled'
 			},
 			discoverToggleSectionsEnabled: {
-				type: Boolean
+				type: Boolean,
+				attribute: 'discover-toggle-sections-enabled'
 			},
 			_savedShowCourseCode: {
 				type: Boolean
@@ -246,9 +252,6 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 			_settingsLoaded: {
 				type: Boolean
 			},
-			token: {
-				type: String
-			}
 		};
 	}
 

--- a/src/discovery-settings.js
+++ b/src/discovery-settings.js
@@ -198,9 +198,6 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 
 	static get properties() {
 		return {
-			visible: {
-				type: Boolean
-			},
 			token: {
 				type: String
 			},
@@ -275,7 +272,7 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 
 	updated(changedProperties) {
 		changedProperties.forEach((_, propName) => {
-			if (propName === 'canManageDiscover' || propName === 'visible') {
+			if (propName === 'canManageDiscover') {
 				this._checkPermission();
 				this._initializeSettings();
 			}
@@ -385,7 +382,7 @@ class DiscoverySettings extends SkeletonMixin(DiscoverSettingsMixin(LocalizeMixi
 	}
 
 	_checkPermission() {
-		if (!this.visible || this.canManageDiscover) {
+		if (this.canManageDiscover) {
 			return;
 		}
 

--- a/src/mixins/route-locations-mixin.js
+++ b/src/mixins/route-locations-mixin.js
@@ -3,13 +3,51 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import createDOMPurify from 'dompurify/dist/purify.es.js';
 const DOMPurify = createDOMPurify(window);
 
-var discoveryBasePath = '/d2l/le/discovery/view';
+const discoveryBasePath = '/d2l/le/discovery/view';
 
 /* @polymerMixin */
 const internalRouteLocationsMixin = (superClass) =>
 	class extends superClass {
 		constructor() {
 			super();
+		}
+
+		//Manages the expected routes and the names of associated pages for each route.
+		static get routes() {
+			return [
+				{
+					name: 'home',
+					pattern: discoveryBasePath + '/'
+				},
+				{
+					name: 'home',
+					pattern: discoveryBasePath + '/home'
+				},
+				{
+					name: 'settings',
+					pattern: discoveryBasePath + '/settings'
+				},
+				{
+					name: 'course',
+					pattern: discoveryBasePath + '/course/:id'
+				},
+				{
+					name: 'search',
+					pattern: discoveryBasePath + '/search'
+				},
+				{
+					name: 'notFound',
+					pattern: '*'
+				}
+			];
+		}
+
+		//Triggers upon this.navigate.
+		//Divides the resulting query up into components to be passed to child components as necessary, based on route name and pattern.
+		router(route, params, query) {
+			this.route = route; //The name of the route
+			this.params = params; //The parameters passed to the route ie courseId
+			this.query = query;// The query of the route, ie search query and sort.
 		}
 
 		search(query, queryParams = {}) {


### PR DESCRIPTION
Implements a simple, data-driven single page app routing behavior using `lit-element-router`.

Discover-App has been rewritten in Lit. Only a single page of Discover will load at a time.

Changes the course page and the search page to be passed their respective ID and query information via attributes, removing their dependency on parsing the URL themselves. This functionality will require further work. However, the end result should be greatly simplified compared to the current implementation.

Tested to ensure navigation between all pages is functional. Ensured refreshing on each page results in the expected page to load, and unexpected URLS will send the user to the 404 page.

`page.js` was also considered, but `lit-element-router` was simpler to implement and provided all necessary functionality and documentation for this use case. They are approximately the same size and I couldn't find any drawbacks or missing features that page.js would be able to offer.

Note that just for testing this, because of the new dependency, you may need to install `lit-element-router` into your local BSI for the dependencies to load correctly.

This PR is necessary to unblock remaining work for the defra-ing process. There are plans to unwind the routing behaviour further from discover-fra such that it could behave more generically at a future date.