### PR TITLE
relax pagination component version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "buildDev:customNoWatch": "npx gulp buildDevCustomNoWatch"
   },
   "dependencies": {
-    "@brightspace-ui-labs/pagination": "^1.0.0",
+    "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui/core": "^1.83.1",
     "@polymer/app-route": "^3.0.0-pre.15",
     "@polymer/iron-pages": "^3.0.0-pre.15",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "buildDev:customNoWatch": "npx gulp buildDevCustomNoWatch"
   },
   "dependencies": {
-    "@brightspace-ui-labs/pagination": "0.0.8",
+    "@brightspace-ui-labs/pagination": "^1.0.0",
     "@brightspace-ui/core": "^1.83.1",
     "@polymer/app-route": "^3.0.0-pre.15",
     "@polymer/iron-pages": "^3.0.0-pre.15",


### PR DESCRIPTION
**Context:**
We've published a new version of the pagination labs component that contains no code changes but just a different CI/release workflow using GitHub Actions. Because discovery-fra is using a fixed version, it's currently preventing us from upgrading to this new version and breaking BSI builds.

 **Quality:**
This will result in no code changes. Here's the actual diff:
https://github.com/BrightspaceUILabs/pagination/compare/v0.0.8...v1.0.1