### PR TITLE
Bhamelin/us122731 fix large swim lanes

### DIFF
--- a/src/components/activity-card-list.js
+++ b/src/components/activity-card-list.js
@@ -87,8 +87,10 @@ class ActivityCardList extends mixinBehaviors([IronResizableBehavior], PolymerEl
 
 		// Calculate container width by walking up its parent;
 		var containerWidth = this.offsetWidth;
-		for (var parent = this.parentNode; containerWidth <= 0 && parent; parent = parent.parentNode) {
-			containerWidth = parent.offsetWidth;
+		for (var parent = this._getHostElement(this); containerWidth <= 0 && parent; parent = this._getHostElement(parent)) {
+			if (parent.offsetWidth !== undefined && parent.offsetWidth > 0) {
+				containerWidth = parent.offsetWidth;
+			}
 		}
 
 		// Determine number of columns and its appropriate columns css
@@ -120,6 +122,14 @@ class ActivityCardList extends mixinBehaviors([IronResizableBehavior], PolymerEl
 				}
 			}
 		}
+	}
+
+	//Traverse up through shadowDOM to find our parent.
+	_getHostElement(element) {
+		if (element.parentNode) {
+			return element.parentNode;
+		}
+		return element.host;
 	}
 }
 

--- a/src/components/activity-card-list.js
+++ b/src/components/activity-card-list.js
@@ -88,7 +88,7 @@ class ActivityCardList extends mixinBehaviors([IronResizableBehavior], PolymerEl
 		// Calculate container width by walking up its parent;
 		var containerWidth = this.offsetWidth;
 		for (var parent = this._getHostElement(this); containerWidth <= 0 && parent; parent = this._getHostElement(parent)) {
-			if (parent.offsetWidth !== undefined && parent.offsetWidth > 0) {
+			if (parent.offsetWidth !== undefined) {
 				containerWidth = parent.offsetWidth;
 			}
 		}


### PR DESCRIPTION
This PR fixes the activity card list being unable to calculate its width as a result of migrating to shadowDOM.

When the cards are hidden during initial load, they previously would walk up the DOM to find the first nonzero `offsetWidth` for a parent (all hidden elements have `offsetWidth = 0`). It would then do some calculations to determine how best to render the cards.

Due to shadowDOM, the previous method of walking up the DOM no longer worked correctly. This has been changed to allow it to traverse hosts, letting it get the width of the first non-hidden parent component. 