### PR TITLE
Changed where cache was removed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "discovery",
   "appId": "urn:d2l:fra:class:discovery",
   "description": "Discovery",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "repository": "git@github.com:Brightspace/discovery-fra.git",

--- a/src/mixins/discover-settings-mixin.js
+++ b/src/mixins/discover-settings-mixin.js
@@ -23,7 +23,7 @@ export const DiscoverSettingsMixin = FetchMixin => class extends FetchMixin {
 
 	async fetchDiscoverSettings() {
 		const url = await this._getActionUrl(getDiscoverSettings);
-		const discoverSettingsEntity = await this._fetchEntityWithoutCache(url);
+		const discoverSettingsEntity = await this._fetchEntity(url);
 		return discoverSettingsEntity && discoverSettingsEntity.properties;
 	}
 

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -25,9 +25,9 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			return;
 		}
 
-		window.d2lfetch.removeTemp('simple-cache');
-
 		const request = await this._createRequest(url, method);
+
+		window.d2lfetch.removeTemp('simple-cache');
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
 			? window.d2lfetch.removeTemp('auth')
@@ -49,9 +49,9 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			return;
 		}
 
-		window.d2lfetch.removeTemp('simple-cache');
-
 		const request = await this._createRequest(url, method);
+
+		window.d2lfetch.removeTemp('simple-cache');
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
 			? window.d2lfetch.removeTemp('auth')

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -25,6 +25,8 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			return;
 		}
 
+		window.d2lfetch.removeTemp('simple-cache');
+
 		const request = await this._createRequest(url, method);
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
@@ -32,7 +34,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			: window.d2lfetch;
 
 		return fetch
-			.removeTemp('simple-cache')
 			.fetch(request)
 			.then(this.__responseToSirenEntity.bind(this));
 	}
@@ -48,6 +49,8 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			return;
 		}
 
+		window.d2lfetch.removeTemp('simple-cache');
+
 		const request = await this._createRequest(url, method);
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
@@ -56,7 +59,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 
 		return fetch
 			.removeTemp('dedupe')
-			.removeTemp('simple-cache')
 			.fetch(request)
 			.then(this.__responseToSirenEntity.bind(this));
 	}

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -1,7 +1,7 @@
 'use strict';
 import 'whatwg-fetch'; // Required for d2l-fetch + IE11
 import { d2lfetch } from 'd2l-fetch/src/index.js';
-window.d2lfetch = d2lfetch;
+window.d2lfetch = d2lfetch.removeTemp('simple-cache');
 
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import SirenParse from 'siren-parser';
@@ -55,29 +55,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 
 		return fetch
 			.removeTemp('dedupe')
-			.fetch(request)
-			.then(this.__responseToSirenEntity.bind(this));
-	}
-
-	async _fetchEntityWithoutCache(sirenLinkOrUrl, method = 'GET') {
-		if (!sirenLinkOrUrl) {
-			return;
-		}
-
-		const url = sirenLinkOrUrl.href || sirenLinkOrUrl;
-
-		if (!url) {
-			return;
-		}
-
-		const request = await this._createRequest(url, method);
-
-		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
-			? window.d2lfetch.removeTemp('auth')
-			: window.d2lfetch;
-
-		return fetch
-			.removeTemp('simple-cache')
 			.fetch(request)
 			.then(this.__responseToSirenEntity.bind(this));
 	}

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -1,7 +1,7 @@
 'use strict';
 import 'whatwg-fetch'; // Required for d2l-fetch + IE11
 import { d2lfetch } from 'd2l-fetch/src/index.js';
-window.d2lfetch = d2lfetch.removeTemp('simple-cache');
+window.d2lfetch = d2lfetch;
 
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import SirenParse from 'siren-parser';
@@ -32,6 +32,7 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			: window.d2lfetch;
 
 		return fetch
+			.removeTemp('simple-cache')
 			.fetch(request)
 			.then(this.__responseToSirenEntity.bind(this));
 	}
@@ -55,6 +56,7 @@ const internalFetchMixin = (superClass) => class extends superClass {
 
 		return fetch
 			.removeTemp('dedupe')
+			.removeTemp('simple-cache')
 			.fetch(request)
 			.then(this.__responseToSirenEntity.bind(this));
 	}


### PR DESCRIPTION
Instead of having a specific function where `simple-cache` is removed, it gets removed at the very beginning of `fetch-mixin.js` so that it always applies.