### PR TITLE
Fixed the featured and search results card size

### DIFF
--- a/src/components/d2l-discover-list/d2l-discover-list.js
+++ b/src/components/d2l-discover-list/d2l-discover-list.js
@@ -351,8 +351,8 @@ class D2lDiscoverList extends FetchMixin(LocalizeMixin(DiscoverListItemResponsiv
 			.d2l-discover-list-item-image {
 				flex-shrink: 0;
 				margin-right: 1.2rem;
-				width: 216px;
-				height: 120px;
+				width: 90px;
+				height: 52px;
 				display: flex;
 				align-items: center;
 				justify-content: center;

--- a/src/components/discover-settings-promoted-content.js
+++ b/src/components/discover-settings-promoted-content.js
@@ -126,8 +126,8 @@ class DiscoverSettingsPromotedContent extends SkeletonMixin(DiscoverSettingsMixi
 				margin-bottom: .5rem;
 			}
 			.img-skeleton {
-				width: 180px;
-				height: 76.66px;
+				width: 90px;
+				height: 44.86px;
 			}
 			.discovery-featured-placeholder-container {
 				width: 100%


### PR DESCRIPTION
This PR covers `issue #10` from [regression testing](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F430355279724).
Because of the removal of iFrames due to the FRA -> BSI conversion, the image sizes on the search and settings pages changed to be their intended sizes, which were too big.
