### PR TITLE
Course banner uses d2l-organization-image

### DIFF
--- a/src/discovery-app.js
+++ b/src/discovery-app.js
@@ -91,7 +91,7 @@ export class DiscoveryApp extends (navigator(router(FetchMixin(FeatureMixin(Rout
 				</discovery-settings>`;
 
 			case 'course': return html `
-				<discovery-course name="course" course-id="${this.params.id}"></discovery-course>`;
+				<discovery-course name="course" token="${this.resolvedToken}" course-id="${this.params.id}"></discovery-course>`;
 
 			case 'search': return html `
 				<discovery-search name="search" .queryParams="${this.query}"></discovery-search>`;

--- a/src/discovery-course.js
+++ b/src/discovery-course.js
@@ -1,6 +1,6 @@
 'use strict';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { Classes, Rels } from 'd2l-hypermedia-constants';
+import { Rels } from 'd2l-hypermedia-constants';
 import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { LocalizeMixin } from './mixins/localize-mixin.js';
@@ -354,8 +354,6 @@ class DiscoveryCourse extends mixinBehaviors(
 			&& organizationEntity.getLinkByRel(Rels.organizationHomepage).href;
 
 		this._dataIsReadyProcess();
-
-
 		return Promise.resolve();
 	}
 
@@ -472,7 +470,7 @@ class DiscoveryCourse extends mixinBehaviors(
 		this.courseImageIsReady = true;
 	}
 	_clearHeaderImage() {
-		this._bannerImageHref = "";
+		this._bannerImageHref = '';
 	}
 	_dataIsReadyProcess() {
 		this._dataIsReady = true;

--- a/src/discovery-course.js
+++ b/src/discovery-course.js
@@ -408,8 +408,6 @@ class DiscoveryCourse extends mixinBehaviors(
 		this._endDateIsoFormat = '';
 		this._dataIsReady = false;
 		this.courseImageIsReady = false;
-
-		this._clearHeaderImage();
 	}
 	_navigateToHome() {
 		this.dispatchEvent(new CustomEvent('navigate', {
@@ -469,9 +467,7 @@ class DiscoveryCourse extends mixinBehaviors(
 		}
 		this.courseImageIsReady = true;
 	}
-	_clearHeaderImage() {
-		this._bannerImageHref = '';
-	}
+
 	_dataIsReadyProcess() {
 		this._dataIsReady = true;
 		const courseSummary = this.shadowRoot.querySelector('#discovery-course-summary');


### PR DESCRIPTION
This PR resolves Issue #3 in [US120307](https://rally1.rallydev.com/#/detail/userstory/430355279724?fdp=true): Discover - Regression testing

As well as [DE38498](https://rally1.rallydev.com/#/detail/defect/379798001088?fdp=true): Discover - Discover-Course component should use a subcomponent for background image

Previously there was an odd structure to load course banners, where the image information would be directly fetched, and then the largest image resolution was loaded into a hidden image. The URL was then copied into a `<div>` and used as a background image.

This has been simplified to just fetch via `<d2l-organization-image.>` This also fixes the BSI fetching issue as it completes the fetch call with proper headers to avoid violating CORS policy. 

As an added bonus, instead of just fetching the `getDefaultImageLink` image, which seems to be the largest banner available, it will dynamically choose the appropriate image to load based on screen width and adjust upwards as necessary. This will allow it to load marginally quicker on some devices and maybe reduce a bit of compression.