### PR TITLE
Reprioritized the hidden property in featured

### DIFF
--- a/src/components/featured-list-section.js
+++ b/src/components/featured-list-section.js
@@ -61,6 +61,10 @@ class FeaturedListSection extends EntityMixinLit(RouteLocationsMixin(LocalizeMix
 						font-size: 0.7rem;
 					}
 				}
+
+				[hidden] {
+					display: none !important;
+				}
 			`
 		];
 	}


### PR DESCRIPTION
Similar to the fixes that happened in the Updated and All swimlanes, the featured swimlane title is now hidden when there is no content in it.