### PR TITLE
bhamelin/fetch call cache fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 node_modules/
 ifrautoaster-custom.json
+debug.log

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,6 @@
+[1209/155327.700:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1209/160147.454:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1209/160348.139:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1209/160511.027:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1209/160544.684:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1209/172056.785:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/debug.log
+++ b/debug.log
@@ -1,6 +1,0 @@
-[1209/155327.700:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[1209/160147.454:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[1209/160348.139:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[1209/160511.027:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[1209/160544.684:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[1209/172056.785:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -8,6 +8,8 @@ import SirenParse from 'siren-parser';
 import 'promise-polyfill/src/polyfill.js';
 import 'url-polyfill/url-polyfill.min.js';
 
+window.d2lfetch = d2lfetch.removeTemp('simple-cache');
+
 /* @polymerMixin */
 const internalFetchMixin = (superClass) => class extends superClass {
 	constructor() {
@@ -27,7 +29,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 
 		const request = await this._createRequest(url, method);
 
-		window.d2lfetch.removeTemp('simple-cache');
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
 			? window.d2lfetch.removeTemp('auth')
@@ -51,7 +52,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 
 		const request = await this._createRequest(url, method);
 
-		window.d2lfetch.removeTemp('simple-cache');
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
 			? window.d2lfetch.removeTemp('auth')

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -1,14 +1,12 @@
 'use strict';
 import 'whatwg-fetch'; // Required for d2l-fetch + IE11
 import { d2lfetch } from 'd2l-fetch/src/index.js';
-window.d2lfetch = d2lfetch;
+window.d2lfetch = d2lfetch.removeTemp('simple-cache');
 
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import SirenParse from 'siren-parser';
 import 'promise-polyfill/src/polyfill.js';
 import 'url-polyfill/url-polyfill.min.js';
-
-window.d2lfetch = d2lfetch.removeTemp('simple-cache');
 
 /* @polymerMixin */
 const internalFetchMixin = (superClass) => class extends superClass {
@@ -28,7 +26,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 		}
 
 		const request = await this._createRequest(url, method);
-
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
 			? window.d2lfetch.removeTemp('auth')
@@ -51,7 +48,6 @@ const internalFetchMixin = (superClass) => class extends superClass {
 		}
 
 		const request = await this._createRequest(url, method);
-
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
 			? window.d2lfetch.removeTemp('auth')


### PR DESCRIPTION
the simple-cache call doesn't seem to apply correctly in the current location.
Moving it into the fetch return itself seems to apply as desired.

This can be confirmed by editing the discover settings, saving, and pressing cancel or checking the homepage.
Without this PR, there is a significant delay before the update occurs.
With this PR, it seems to apply the saved changes immediately.