### PR TITLE
Add important hiding to resolve hidden not applying

### DIFF
--- a/src/discovery-course.js
+++ b/src/discovery-course.js
@@ -83,6 +83,10 @@ class DiscoveryCourse extends mixinBehaviors(
 					border-bottom: 1px solid var(--d2l-color-gypsum);
 				}
 
+				[hidden] {
+					display: none !important;
+				}
+
 				@media only screen and (max-width: 929px) {
 					.discovery-course-container {
 						align-items: center;


### PR DESCRIPTION
Added hide - important to get the hidden attribute to apply to the course info box.

Tested with different combinations of dates and course codes to ensure the box only appeared as necessary.
Tested the rest of the features of the page to ensure the rest of it shouldn't be changed as well.