### PR TITLE
Made the View All hyperlinks consistent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "discovery",
   "appId": "urn:d2l:fra:class:discovery",
   "description": "Discovery",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "repository": "git@github.com:Brightspace/discovery-fra.git",

--- a/src/components/home-all-section.js
+++ b/src/components/home-all-section.js
@@ -28,16 +28,6 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 					align-items: center;
 				}
 
-				.activity-card-list-header-view-all-link {
-					@apply --d2l-body-compact-text;
-				}
-
-				@media only screen and (max-width: 615px) {
-					.activity-card-list-header-view-all-link {
-						font-size: 0.7rem;
-					}
-				}
-
 				[hidden] {
 					display: none !important;
 				}
@@ -48,7 +38,6 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 						<h2 class="d2l-heading-2" aria-label$="[[localize('all')]]">[[localize('all')]]</h2>
 						<d2l-link
 							aria-label$="[[localize('viewAllLabel')]]"
-							class="activity-card-list-header-view-all-link"
 							href="javascript:void(0)"
 							on-click="_navigateToViewAll">
 							[[localize('viewAll')]]

--- a/src/components/home-all-section.js
+++ b/src/components/home-all-section.js
@@ -28,6 +28,12 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 					align-items: center;
 				}
 
+				@media only screen and (max-width: 615px) {	
+					.activity-card-list-header-view-all-link {	
+						font-size: 0.8rem;	
+					}	
+				}
+
 				[hidden] {
 					display: none !important;
 				}
@@ -37,6 +43,7 @@ class HomeAllSection extends RouteLocationsMixin(FetchMixin(LocalizeMixin(Polyme
 					<div class="activity-card-list-header">
 						<h2 class="d2l-heading-2" aria-label$="[[localize('all')]]">[[localize('all')]]</h2>
 						<d2l-link
+							class="activity-card-list-header-view-all-link"
 							aria-label$="[[localize('viewAllLabel')]]"
 							href="javascript:void(0)"
 							on-click="_navigateToViewAll">

--- a/src/components/home-list-section.js
+++ b/src/components/home-list-section.js
@@ -19,7 +19,6 @@ class HomeListSection extends EntityMixinLit(RouteLocationsMixin(LitElement)) {
 						<h2 class="d2l-heading-2" aria-label="${this.sectionName}">${this.sectionName}</h2>
 						<d2l-link
 							aria-label="${this.linkLabel}"
-							class="activity-card-list-header-view-all-link"
 							href="javascript:void(0)"
 							@click="${this._navigateToViewAll}">
 							${this.linkName}
@@ -51,16 +50,6 @@ class HomeListSection extends EntityMixinLit(RouteLocationsMixin(LitElement)) {
 					display: flex;
 					justify-content: space-between;
 					align-items: center;
-				}
-
-				.activity-card-list-header-view-all-link {
-					@apply --d2l-body-compact-text;
-				}
-
-				@media only screen and (max-width: 615px) {
-					.activity-card-list-header-view-all-link {
-						font-size: 0.7rem;
-					}
 				}
 			`
 		];


### PR DESCRIPTION
In order to make them all consistent, I removed the modified that was causing the `View All` hyperlink in the `All` swimlane. The reason for the inconsistency may have been because `home-all-section.js` uses Polymer while `home-list-section.js` uses Lit, and as a result the formatting wasn't being applied the intended way.