### PR TITLE
Update the major version of facet-filter-sort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -987,6 +987,20 @@
         "lit-element": "^2"
       }
     },
+    "@brightspace-ui-labs/facet-filter-sort": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/facet-filter-sort/-/facet-filter-sort-4.1.0.tgz",
+      "integrity": "sha512-8dlqmjK3ybzFG9JWwXH48MjDkkMA2oQPMC53iJnVZvBcWBtuTkGVKuc6DSzmBISbpwceruwradpTE624S2jGfg==",
+      "requires": {
+        "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
+        "@brightspace-ui/core": "^1",
+        "@polymer/polymer": "^3",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "lit-element": "^2"
+      }
+    },
     "@brightspace-ui-labs/list-item-accumulator": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/list-item-accumulator/-/list-item-accumulator-1.0.7.tgz",
@@ -5173,12 +5187,27 @@
       }
     },
     "d2l-common": {
-      "version": "github:BrightspaceHypermediaComponents/common#77e3223755cdd61b4bee00b9fb3463f0dd345c31",
+      "version": "github:BrightspaceHypermediaComponents/common#c9f4e4bd3678835c1f01811a432d7ddfd4851c97",
       "from": "github:BrightspaceHypermediaComponents/common#semver:^3",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "d2l-facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1"
+      },
+      "dependencies": {
+        "d2l-facet-filter-sort": {
+          "version": "github:BrightspaceUI/facet-filter-sort#8b8d50298410d5d2c0eaf07b6b5e1265114a1628",
+          "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
+          "requires": {
+            "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
+            "@brightspace-ui/core": "^1",
+            "@polymer/polymer": "^3",
+            "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+            "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+            "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+            "lit-element": "^2"
+          }
+        }
       }
     },
     "d2l-content-icons": {
@@ -5249,19 +5278,6 @@
       "requires": {
         "@brightspace-ui/core": "^1.31",
         "@polymer/polymer": "^3"
-      }
-    },
-    "d2l-facet-filter-sort": {
-      "version": "github:BrightspaceUI/facet-filter-sort#8b8d50298410d5d2c0eaf07b6b5e1265114a1628",
-      "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
-      "requires": {
-        "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
-        "@brightspace-ui/core": "^1",
-        "@polymer/polymer": "^3",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
-        "lit-element": "^2"
       }
     },
     "d2l-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5187,27 +5187,12 @@
       }
     },
     "d2l-common": {
-      "version": "github:BrightspaceHypermediaComponents/common#c9f4e4bd3678835c1f01811a432d7ddfd4851c97",
+      "version": "github:BrightspaceHypermediaComponents/common#eae7b1c61dc2b69cd13799a636e029550edc838d",
       "from": "github:BrightspaceHypermediaComponents/common#semver:^3",
       "requires": {
+        "@brightspace-ui-labs/facet-filter-sort": "^4",
         "@polymer/polymer": "^3.0.0",
-        "d2l-facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1"
-      },
-      "dependencies": {
-        "d2l-facet-filter-sort": {
-          "version": "github:BrightspaceUI/facet-filter-sort#8b8d50298410d5d2c0eaf07b6b5e1265114a1628",
-          "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
-          "requires": {
-            "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
-            "@brightspace-ui/core": "^1",
-            "@polymer/polymer": "^3",
-            "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-            "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-            "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
-            "lit-element": "^2"
-          }
-        }
       }
     },
     "d2l-content-icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "discovery",
   "appId": "urn:d2l:fra:class:discovery",
   "description": "Discovery",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "repository": "git@github.com:Brightspace/discovery-fra.git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "buildDev:customNoWatch": "npx gulp buildDevCustomNoWatch"
   },
   "dependencies": {
+    "@brightspace-ui-labs/facet-filter-sort": "^4",
     "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui/core": "^1.102.5",
     "@polymer/app-route": "^3.0.0-pre.15",
@@ -35,7 +36,6 @@
     "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3",
     "d2l-activities": "github:BrightspaceHypermediaComponents/activities#semver:^3",
-    "d2l-facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
     "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
     "d2l-fetch-auth": "^1",
     "d2l-fetch-dedupe": "^1.3.0",
@@ -56,7 +56,6 @@
   },
   "devDependencies": {
     "@babel/polyfill": "^7.12.1",
-    "@d2l/ifrautoaster": "^1.1.9",
     "@polymer/iron-component-page": "^3.0.0-pre.18",
     "@polymer/iron-test-helpers": "^3.0.0-pre.18",
     "@webcomponents/webcomponentsjs": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@babel/polyfill": "^7.12.1",
+    "@d2l/ifrautoaster": "^1.1.9",
     "@polymer/iron-component-page": "^3.0.0-pre.18",
     "@polymer/iron-test-helpers": "^3.0.0-pre.18",
     "@webcomponents/webcomponentsjs": "^2.5.0",

--- a/src/components/search-results.js
+++ b/src/components/search-results.js
@@ -1,13 +1,13 @@
 'use strict';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/sort-by-dropdown/sort-by-dropdown-option.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/sort-by-dropdown/sort-by-dropdown.js';
 import '@brightspace-ui-labs/pagination/pagination.js';
 import '@brightspace-ui/core/components/link/link.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import 'd2l-typography/d2l-typography.js';
 import 'fastdom/fastdom.js';
-import 'd2l-facet-filter-sort/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js';
-import 'd2l-facet-filter-sort/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js';
 import { FetchMixin } from '../mixins/fetch-mixin.js';
 import { RouteLocationsMixin } from '../mixins/route-locations-mixin.js';
 import { LocalizeMixin } from '../mixins/localize-mixin.js';
@@ -127,24 +127,24 @@ class SearchResults extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 									<span class="d2l-label-text discovery-search-results-search-message">[[localize('searchResultCountForAllResults', 'searchResultRange', _searchResultsRangeToString, 'searchResultsTotal', _searchResultsTotal)]]</span>
 								</div>
 							</template>
-							<d2l-sort-by-dropdown id="sortDropdown" label="Sort by options" align="end">
-								<d2l-sort-by-dropdown-option
+							<d2l-labs-sort-by-dropdown id="sortDropdown" label="Sort by options" align="end">
+								<d2l-labs-sort-by-dropdown-option
 									selected="[[_isSelected('relevant')]]"
 									value="relevant"
-									text="[[getSortText('relevant')]]"></d2l-sort-by-dropdown-option>
-								<d2l-sort-by-dropdown-option
+									text="[[getSortText('relevant')]]"></d2l-labs-sort-by-dropdown-option>
+								<d2l-labs-sort-by-dropdown-option
 									selected="[[_isSelected('updated')]]"
 									value="updated"
-									text="[[getSortText('updated')]]"></d2l-sort-by-dropdown-option>
-								<d2l-sort-by-dropdown-option
+									text="[[getSortText('updated')]]"></d2l-labs-sort-by-dropdown-option>
+								<d2l-labs-sort-by-dropdown-option
 									selected="[[_isSelected('added')]]"
 									value="added"
-									text="[[getSortText('added')]]"></d2l-sort-by-dropdown-option>
-								<d2l-sort-by-dropdown-option
+									text="[[getSortText('added')]]"></d2l-labs-sort-by-dropdown-option>
+								<d2l-labs-sort-by-dropdown-option
 									selected="[[_isSelected('enrolled')]]"
 									value="enrolled"
-									text="[[getSortText('enrolled')]]"></d2l-sort-by-dropdown-option>
-							</d2l-sort-by-dropdown>
+									text="[[getSortText('enrolled')]]"></d2l-labs-sort-by-dropdown-option>
+							</d2l-labs-sort-by-dropdown>
 						</template>
 					</template>
 				</div>
@@ -241,7 +241,7 @@ class SearchResults extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 		this.addEventListener('d2l-discover-activity-triggered', this._navigateToCourse.bind(this));
 		this.addEventListener('d2l-discover-text-loaded', this._removeTextPlaceholders);
 		this.addEventListener('d2l-discover-image-loaded', this._removeImagePlaceholders);
-		this.addEventListener('d2l-sort-by-dropdown-change', this._onSortChanged.bind(this));
+		this.addEventListener('d2l-labs-sort-by-dropdown-change', this._onSortChanged.bind(this));
 	}
 
 	_isSelected(item) {
@@ -321,7 +321,7 @@ class SearchResults extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 	}
 
 	setSortSelection() {
-		const sortOptions = this.shadowRoot.querySelectorAll('#sortDropdown d2l-sort-by-dropdown-option');
+		const sortOptions = this.shadowRoot.querySelectorAll('#sortDropdown d2l-labs-sort-by-dropdown-option');
 		for (const option of sortOptions) {
 			option.selected = option.value === this.sortParameter;
 		}

--- a/test/components/search-results-test.js
+++ b/test/components/search-results-test.js
@@ -261,7 +261,7 @@ describe('search-results', () => {
 
 		it('should show 4 sort options with enrolled sort option selected', done => {
 			afterNextRender(component, () => {
-				const sortOptions = component.shadowRoot.querySelectorAll('#sortDropdown d2l-sort-by-dropdown-option');
+				const sortOptions = component.shadowRoot.querySelectorAll('#sortDropdown d2l-labs-sort-by-dropdown-option');
 				expect(sortOptions.length).to.equal(4);
 				const sortDropdown = component.shadowRoot.querySelector('#sortDropdown');
 				expect(sortDropdown).is.not.undefined;


### PR DESCRIPTION
Moving to `facet-filter-sort` version 4, which renamed all the components, files and events to indicate these components are in labs - no functionality changes. This version is also published to npm, which cleans up the `package.json` entry.

This needs to be merged at the same time as the PRs in `my-courses` (https://github.com/Brightspace/d2l-my-courses-ui/pull/882), `common` (https://github.com/BrightspaceHypermediaComponents/common/pull/43) and `insights-engagement-dashboard` (https://github.com/Brightspace/insights-engagement-dashboard/pull/316) to avoid any BSI downtime.
