### PR TITLE
DE43191  Entitled Course Navigates to 404 Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "discovery",
   "appId": "urn:d2l:fra:class:discovery",
   "description": "Discovery",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "repository": "git@github.com:Brightspace/discovery-fra.git",

--- a/src/discovery-course.js
+++ b/src/discovery-course.js
@@ -329,7 +329,7 @@ class DiscoveryCourse extends mixinBehaviors(
 	async _handleOrganizationEntity(organizationEntity) {
 		if (!organizationEntity) return Promise.reject();
 
-		if (!organizationEntity.hasClass('active') || !organizationEntity.hasClass('self-assignable')) {
+		if (!organizationEntity.hasClass('active')) {
 			this._navigateToNotFound();
 			return;
 		}


### PR DESCRIPTION
A trivial PR that fixes the 404 page for entitled courses.  The fundamental issue is that we've redefined self-assignability.  There used to be a universal course property that determines whether a course were self-assignable or not and that's what the course page used to check.  Now, a course may be self-assignable by that course property _or_ it may be entitled to self-assignability, according to the Entitlement service.  Because we have no opportunity to check with the Entitlement service, no further action is taken.  The only way to get this page for non-self-assignable courses would be manually alter the URL and no unauthorized action can be successfully made because all non-GET operations are checked for validity and permission by the BFF...