### PR TITLE
Add bypass cache and utilize for fetching the course

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,6 +709,15 @@
         "siren-parser": "^8.2.0"
       },
       "dependencies": {
+        "@brightspace-ui-labs/attribute-picker": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/attribute-picker/-/attribute-picker-1.0.9.tgz",
+          "integrity": "sha512-MhqqSvqH9Uyz9t+2CqUGMFf1QU8s6TsdpETel7A+CJ2uzRDIfC4IvAFQMLnhTDzP6zrTUr/8IMBK6q0yL2OBiw==",
+          "requires": {
+            "@brightspace-ui/core": "^1",
+            "lit-element": "^2"
+          }
+        },
         "@brightspace-ui/core": {
           "version": "1.141.0",
           "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.141.0.tgz",
@@ -724,6 +733,11 @@
             "prismjs": "^1",
             "resize-observer-polyfill": "^1"
           }
+        },
+        "@brightspace-ui/intl": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.5.0.tgz",
+          "integrity": "sha512-LtACe003NPja10qINoGr5oUIUukNVwHWEhM76C/yuIMHquPCeJmC3m7whrDfUP8OzxrcdyOryuZqZj3xFRJuaQ=="
         }
       }
     },
@@ -752,15 +766,6 @@
         "@polymer/iron-flex-layout": "^3.0.0-pre.18",
         "@polymer/iron-selector": "^3.0.0-pre.18",
         "@polymer/polymer": "^3"
-      }
-    },
-    "@brightspace-ui-labs/attribute-picker": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/attribute-picker/-/attribute-picker-1.0.8.tgz",
-      "integrity": "sha512-LhluivHBOAItkazwA6vFrfCL9atRQNt+5XD2zLpbXmekvCL81UgpyuisbAjp7uHVuiVv9sm1zMVDuHIyY/5ZIg==",
-      "requires": {
-        "@brightspace-ui/core": "^1",
-        "lit-element": "^2"
       }
     },
     "@brightspace-ui-labs/caketray": {
@@ -855,9 +860,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.126.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.126.3.tgz",
-      "integrity": "sha512-xQPu5UkT0xSKQnswsywJ3u5uAj5kghqzZmb1JKIQyXhzUGAeKgbNZ/3QqOGhzGGYKxV8KsF42J+ehr18Lx1m3Q==",
+      "version": "1.141.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.141.0.tgz",
+      "integrity": "sha512-XyMoSvprxw/kVvxXubTOwPlOpjTKhbsDDJOMhBFJXhrn0u8asRh+PoYDDuGv823k4o4fUtV7XVpfMgcp8qMzsQ==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
@@ -5538,6 +5543,7 @@
       "version": "github:BrightspaceUI/table#ec7bd70e54fd319da7f98335dee14f9b3ef13bd7",
       "from": "github:BrightspaceUI/table#semver:^2",
       "requires": {
+        "@brightspace-ui/core": "^1.134",
         "@polymer/polymer": "^3",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "fastdom": "^1.0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -695,17 +695,36 @@
       "requires": {
         "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",
         "@brightspace-ui-labs/accordion": "^2.4.2",
-        "@brightspace-ui-labs/attribute-picker": "^1.0.7",
+        "@brightspace-ui-labs/attribute-picker": "^1.0.9",
         "@brightspace-ui-labs/caketray": "^1",
         "@brightspace-ui-labs/checkbox-drawer": "github:BrightspaceUILabs/checkbox-drawer#semver:^1",
         "@brightspace-ui-labs/list-item-accumulator": "^1",
-        "@brightspace-ui/core": "^1.126.4",
-        "@brightspace-ui/intl": "^3.4.0",
+        "@brightspace-ui-labs/pagination": "^1.0.2",
+        "@brightspace-ui/core": "^1.130.0",
+        "@brightspace-ui/intl": "^3.5.0",
         "d2l-course-image": "github:Brightspace/course-image#semver:^3",
         "d2l-navigation": "github:BrightspaceUI/navigation#semver:^4",
         "lit-element": "^2",
         "lit-html": "^1.3.0",
         "siren-parser": "^8.2.0"
+      },
+      "dependencies": {
+        "@brightspace-ui/core": {
+          "version": "1.141.0",
+          "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.141.0.tgz",
+          "integrity": "sha512-XyMoSvprxw/kVvxXubTOwPlOpjTKhbsDDJOMhBFJXhrn0u8asRh+PoYDDuGv823k4o4fUtV7XVpfMgcp8qMzsQ==",
+          "requires": {
+            "@brightspace-ui/intl": "^3",
+            "@formatjs/intl-pluralrules": "^1",
+            "@open-wc/dedupe-mixin": "^1.2.17",
+            "@webcomponents/shadycss": "^1",
+            "focus-visible": "^5",
+            "intl-messageformat": "^7",
+            "lit-element": "^2",
+            "prismjs": "^1",
+            "resize-observer-polyfill": "^1"
+          }
+        }
       }
     },
     "@brightspace-hmc/foundation-engine": {
@@ -791,18 +810,6 @@
       "requires": {
         "@brightspace-ui/core": "^1",
         "lit-element": "^2"
-      }
-    },
-    "@brightspace-ui-labs/media-player": {
-      "version": "1.37.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/media-player/-/media-player-1.37.3.tgz",
-      "integrity": "sha512-yL76I01+nomIz9R1w4qUVXwE9BtK2zF4J75kLs927UlzBex/B6YLfFZQcxkglUNxDW7p/v4ypaFgR0a4vnRb0g==",
-      "requires": {
-        "@brightspace-ui/core": "^1",
-        "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
-        "lit-element": "^2",
-        "parse-srt": "^1.0.0-alpha",
-        "resize-observer-polyfill": "^1"
       }
     },
     "@brightspace-ui-labs/multi-select": {
@@ -4646,7 +4653,7 @@
         "@brightspace-ui-labs/accordion": "^2.0.2",
         "@brightspace-ui-labs/edit-in-place": "^1.0.11",
         "@brightspace-ui-labs/list-item-accumulator": "^1",
-        "@brightspace-ui/core": "^1.118.2",
+        "@brightspace-ui/core": "^1.131.3",
         "@brightspace-ui/htmleditor": "^1.2.6",
         "@brightspace-ui/intl": "^3.0.1",
         "@d2l/d2l-attachment": "github:Brightspace/attachment#semver:^1",
@@ -4675,7 +4682,6 @@
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-rubric": "github:Brightspace/d2l-rubric#semver:^3",
         "d2l-save-status": "github:Brightspace/d2l-save-status#semver:^3",
-        "d2l-simple-overlay": "github:Brightspace/simple-overlay#semver:^3",
         "d2l-table": "github:BrightspaceUI/table#semver:^2",
         "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
@@ -4775,6 +4781,7 @@
         "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
+        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
         "d2l-typography": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5",
         "s-html": "github:Brightspace/s-html#semver:^2"
       },
@@ -5098,15 +5105,6 @@
         "intl-messageformat": "^7"
       }
     },
-    "d2l-menu": {
-      "version": "github:BrightspaceUI/menu#437d7efdca44a3b5f5e1611acd2103df72ed47ef",
-      "from": "github:BrightspaceUI/menu#semver:^2",
-      "requires": {
-        "@brightspace-ui/core": "^1.29.1",
-        "@polymer/polymer": "^3.0.0",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2"
-      }
-    },
     "d2l-navigation": {
       "version": "github:BrightspaceUI/navigation#d59066dce1f1b7fd08834a2788c56e9b0389041b",
       "from": "github:BrightspaceUI/navigation#semver:^4",
@@ -5348,34 +5346,25 @@
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",
-        "@brightspace-ui/core": "^1.113.5",
+        "@brightspace-ui/core": "^1.134",
         "@polymer/iron-media-query": "^3.0.0",
         "@polymer/iron-overlay-behavior": "^3.0.2",
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
         "d2l-activity-alignments": "github:Brightspace/d2l-activity-alignments#semver:^2",
-        "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
         "d2l-dnd-sortable": "github:Brightspace/dnd-sortable#semver:^3",
-        "d2l-dropdown": "github:BrightspaceUI/dropdown#semver:^7",
         "d2l-fetch": "github:Brightspace/d2l-fetch#09b1435d43d67e1a27d2a8663524b4840adedb6f",
         "d2l-fetch-siren-entity-behavior": "github:Brightspace/d2l-fetch-siren-entity-behavior#semver:^6",
         "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
-        "d2l-link": "github:BrightspaceUI/link#semver:^5",
-        "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#1110bbcc7b8fe6237167a6020d3a5d3ff4e1b1c9",
-        "d2l-menu": "github:BrightspaceUI/menu#semver:^2",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#18a0f29be6783e5de3401c4dc1a2edee541b9f2c",
         "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#010413bb542a77924b6fabf72f54cc46bfc1995d",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "d2l-save-status": "github:Brightspace/d2l-save-status#semver:^3",
         "d2l-table": "github:BrightspaceUI/table#semver:^2",
         "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
-        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
         "d2l-typography": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5",
         "fastdom": "^1.0.8",
         "s-html": "github:Brightspace/s-html#semver:^2"
@@ -5500,6 +5489,18 @@
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#0af182b09c31b4794bd214e7484d3c42ca7e91ec"
       },
       "dependencies": {
+        "@brightspace-ui-labs/media-player": {
+          "version": "1.37.4",
+          "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/media-player/-/media-player-1.37.4.tgz",
+          "integrity": "sha512-eT7bz2N96cWTf/VE5hEIbmPtalLqKR5EZmYa/ay/G6woaquRCdbbC1O9QscnW/gbFfFVKyyb+sDt744krfxu3Q==",
+          "requires": {
+            "@brightspace-ui/core": "^1",
+            "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
+            "lit-element": "^2",
+            "parse-srt": "^1.0.0-alpha",
+            "resize-observer-polyfill": "^1"
+          }
+        },
         "d2l-fetch": {
           "version": "github:Brightspace/d2l-fetch#09b1435d43d67e1a27d2a8663524b4840adedb6f",
           "from": "github:Brightspace/d2l-fetch#09b1435d43d67e1a27d2a8663524b4840adedb6f"
@@ -5533,40 +5534,13 @@
         }
       }
     },
-    "d2l-simple-overlay": {
-      "version": "github:Brightspace/simple-overlay#62dd71f55cd17711afcc77471073e268186e260d",
-      "from": "github:Brightspace/simple-overlay#semver:^3",
-      "requires": {
-        "@polymer/iron-overlay-behavior": "^3.0.0-pre.18",
-        "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#semver:^5",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-        "d2l-typography": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5"
-      },
-      "dependencies": {
-        "d2l-typography": {
-          "version": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5",
-          "from": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5",
-          "requires": {
-            "@brightspace-ui/core": "^1",
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
-      }
-    },
     "d2l-table": {
       "version": "github:BrightspaceUI/table#ec7bd70e54fd319da7f98335dee14f9b3ef13bd7",
       "from": "github:BrightspaceUI/table#semver:^2",
       "requires": {
-        "@polymer/iron-resizable-behavior": "^3.0.0",
-        "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "@polymer/polymer": "^3",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
-        "fastdom": "^1.0.8",
-        "stickyfilljs": "^2.1.0"
+        "fastdom": "^1.0.8"
       }
     },
     "d2l-telemetry-browser-client": {
@@ -14829,11 +14803,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
-    },
-    "stickyfilljs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stickyfilljs/-/stickyfilljs-2.1.0.tgz",
-      "integrity": "sha512-LkG0BXArL5HbW2O09IAXfnBQfpScgGqJuUDUrI3Ire5YKjRz/EhakIZEJogHwgXeQ4qnTicM9sK9uYfWN11qKg=="
     },
     "stream": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "discovery",
   "appId": "urn:d2l:fra:class:discovery",
   "description": "Discovery",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "repository": "git@github.com:Brightspace/discovery-fra.git",

--- a/src/components/course-summary.js
+++ b/src/components/course-summary.js
@@ -680,7 +680,7 @@ class CourseSummary extends FetchMixin(LocalizeMixin(RouteLocationsMixin(Polymer
 
 	_fetchOrganizationHomepage() {
 		if (this.organizationHref) {
-			return this._fetchEntity(this.organizationHref)
+			return this._fetchEntity(this.organizationHref, 'GET', true)
 				.then((organizationEntity) => {
 					return organizationEntity.hasLink(Rels.organizationHomepage)
 						&& organizationEntity.getLinkByRel(Rels.organizationHomepage).href;

--- a/src/mixins/fetch-mixin.js
+++ b/src/mixins/fetch-mixin.js
@@ -14,7 +14,7 @@ const internalFetchMixin = (superClass) => class extends superClass {
 		super();
 	}
 
-	async _fetchEntity(sirenLinkOrUrl, method = 'GET') {
+	async _fetchEntity(sirenLinkOrUrl, method = 'GET', bypassCache = false) {
 		if (!sirenLinkOrUrl) {
 			return;
 		}
@@ -25,7 +25,7 @@ const internalFetchMixin = (superClass) => class extends superClass {
 			return;
 		}
 
-		const request = await this._createRequest(url, method);
+		const request = await this._createRequest(url, method, bypassCache);
 
 		const fetch = this._shouldSkipAuth(sirenLinkOrUrl)
 			? window.d2lfetch.removeTemp('auth')
@@ -110,13 +110,14 @@ const internalFetchMixin = (superClass) => class extends superClass {
 		return Promise.reject(response.status + ' ' + response.statusText);
 	}
 
-	async _createRequest(url, method) {
+	async _createRequest(url, method, bypassCache) {
 		const token = await this._getToken();
 		const request = new Request(url, {
 			method,
 			headers: {
 				Accept: 'application/vnd.siren+json',
-				Authorization: 'Bearer ' + token
+				Authorization: 'Bearer ' + token,
+				...(bypassCache && {'Cache-Control': 'no-cache'})
 			},
 		});
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/357252275780d/defects?detail=%2Fdefect%2F601644467409

Adds an option in the fetch-mixin to use `Cache-Control: no-cache`, and uses it within the course summary page to reload the course entity from `https://a2270ac7-dbbf-40e0-bf2d-5989731bf2fe.organizations.api.dev.brightspace.com/{courseID}`.

Using this header errors out for certain servers. The error you would get against the BFF for example looks like
`6609:1 Access to fetch at 'https://us-east-1.discovery.bff.dev.brightspace.com/' from origin 'https://artemisdev.devlms.brightspace.com' has been blocked by CORS policy: Request header field Cache-Control is not allowed by Access-Control-Allow-Headers in preflight response`

 I thought I would have to use an alternate solution, but this this header seems to be fine with at least the organizations api.
After implementing this, the enrollment pending message isn't overstaying its welcome any longer.

Tested with Chrome, Firefox and Edge to ensure they are all happy with this header.


